### PR TITLE
Create tabBar component

### DIFF
--- a/src/components/BeagleTabBar/index.tsx
+++ b/src/components/BeagleTabBar/index.tsx
@@ -1,0 +1,70 @@
+/*
+  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+
+import React, { FC } from 'react'
+import { BeagleComponent } from '../../types'
+import { BeagleDefaultComponent } from '../types'
+import withTheme from '../utils/withTheme'
+import { ImagePath } from '../BeagleImage'
+import {
+  StyledTabBar,
+  StyledBeagleTabItem,
+  StyledBeagleTabItemContent,
+  StyledBeagleImage,
+  StyledSelected,
+} from './styled'
+
+export interface ItemTitle {
+  title?: string,
+  icon?: ImagePath,
+}
+
+export interface BeagleTabBarInterface extends BeagleComponent, BeagleDefaultComponent {
+  onTabSelection?: (item: number) => void,
+  currentTab?: number,
+  items: ItemTitle[],
+  styleId?: string,
+}
+
+const BeagleTabBar: FC<BeagleTabBarInterface> = ({
+  onTabSelection, currentTab, items, beagleContext,
+}) => {
+
+  const changeSelectedTab = (index: number) => {
+    if (!onTabSelection) return
+    onTabSelection(index)
+  }
+
+  const tabImage = (item: ItemTitle) => item.icon ? (
+    <StyledBeagleImage path={item.icon} beagleContext={beagleContext}></StyledBeagleImage>
+  ) : null
+
+  return (
+    <StyledTabBar>
+      {items.map((item, index) => (
+        <StyledBeagleTabItem key={index}>
+          <StyledBeagleTabItemContent onClick={() => changeSelectedTab(index)}>
+            {tabImage(item)}
+            {item.title}
+          </StyledBeagleTabItemContent >
+          {index === currentTab && <StyledSelected></StyledSelected>}
+        </StyledBeagleTabItem>
+      ))}
+    </StyledTabBar>
+  )
+}
+
+export default withTheme(BeagleTabBar)

--- a/src/components/BeagleTabBar/styled.ts
+++ b/src/components/BeagleTabBar/styled.ts
@@ -1,0 +1,53 @@
+/*
+  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+
+import styled from 'styled-components'
+import { BeagleTheme } from '../commons.styled'
+import BeagleImage from '../BeagleImage'
+
+export const StyledTabBar = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+export const StyledBeagleTabItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 0 10px;
+`
+
+export const StyledBeagleTabItemContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  min-width: 20px;
+  min-height: 15px;
+
+  &:hover {
+    background-color: ${BeagleTheme.swampTransparent};
+  }
+`
+
+export const StyledBeagleImage= styled(BeagleImage) `
+  max-width: 80px;
+  max-height: 80px;
+`
+
+export const StyledSelected = styled.div`
+  height: 2px;
+  background-color: ${BeagleTheme.swamp};
+`

--- a/src/components/BeagleTabView/index.tsx
+++ b/src/components/BeagleTabView/index.tsx
@@ -24,6 +24,10 @@ export interface BeagleChildren {
   key: string,
 }
 
+/**
+ * @deprecated Since version 1.1. Will be deleted in version 2.0.
+ * Consider replacing this component for a tabBar with a pageview.
+*/
 const BeagleTabView: FC<BeagleDefaultComponent> = props => {
   const { children, className } = props
 
@@ -39,6 +43,8 @@ const BeagleTabView: FC<BeagleDefaultComponent> = props => {
       const firstChildren = children[0] as BeagleChildren
       tabViewContext.setActiveTab(firstChildren.key)
     }
+    console.warn(`Tabview is deprecated. This will be removed in a future version.
+    Please consider replacing this component for a tabBar with a pageview.`)
   }, [])
 
   return (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ import Modal from './Modal'
 import TextArea from './TextArea'
 import BeagleInput from './BeagleInput'
 import BeagleWebView from './BeagleWebView'
+import BeagleTabBar from './BeagleTabBar'
 
 const libRequiredComponents = {
   'custom:error': BeagleError,
@@ -55,6 +56,7 @@ const beagleDefaultComponents = {
   'beagle:lazycomponent': BeagleLazy,
   'beagle:input': BeagleInput,
   'beagle:webview': BeagleWebView,
+  'beagle:tabbar': BeagleTabBar,
 }
 
 const webSpecificComponents = {


### PR DESCRIPTION
**- What I did**
Create new tabBar component which should be used instead of tabView for the new version. As we are not going to allow break changes for this version, we are keeping the tabView but indicating that the component is deprecated.

**- How I did it**
Create tabBar component and associate it as a default component

**- How to verify it**
The playground project in `/#/cloud/2d0c7b6557c544479853a3c9ab6113bd/tabBarRefactor?platform=react-web` should render correctly tabBar component

**- Description for the changelog**
Create tabBar