### PR TITLE
Add show arrow and fix context behavior

### DIFF
--- a/src/components/BeaglePageView/index.tsx
+++ b/src/components/BeaglePageView/index.tsx
@@ -33,10 +33,11 @@ export interface BeaglePageViewInterface extends BeagleDefaultComponent {
   pageIndicator?: PageIndicatorInterface,
   onPageChange?: (index: number) => void,
   currentPage?: number,
+  showArrow?: boolean,
 }
 
 const BeaglePageView: FC<BeaglePageViewInterface> = ({
-  children, onPageChange, currentPage, 
+  children, onPageChange, currentPage, showArrow,
   /**
    * @deprecated Since version 1.1. Will be deleted in version 2.0.
    * Use pageIndicator as a component instead.
@@ -46,12 +47,19 @@ const BeaglePageView: FC<BeaglePageViewInterface> = ({
   const [active, setActive] = useState(currentPage || 0)
   const numberChildren = Children.count(children)
 
+  showArrow = showArrow !== undefined ? showArrow : true
+
   useEffect(() => {
     if (pageIndicator)
-      console.log(`The page view you are using is deprecated. 
+      console.warn(`The page view you are using is deprecated. 
       This will be removed in a future version; please refactor this component 
       using new context features.`)
   }, [])
+
+  useEffect(() => {
+    if (currentPage !== undefined && currentPage !== active)
+      setActive(currentPage)
+  }, [currentPage])
 
   const updatePage = (newPageIndex: number) => {
     if (onPageChange) onPageChange(newPageIndex)
@@ -79,12 +87,21 @@ const BeaglePageView: FC<BeaglePageViewInterface> = ({
     </StyledOrderList>
   ) : null
 
+  const rightArrow = showArrow ? (
+    <StyledRightArrow onClick={nextSlide}>
+      <KeyBoardArrow />
+    </StyledRightArrow>
+  ) : null
+
+  const leftArrow = showArrow ? (
+    <StyledLeftArrow onClick={backSlide} >
+      <KeyBoardArrow />
+    </StyledLeftArrow>
+  ) : null
+
   return (
     <StyledBeaglePageView>
-      <StyledLeftArrow onClick={backSlide} >
-        <KeyBoardArrow />
-      </StyledLeftArrow>
-
+      {leftArrow}
       <StyleContentItems>
         {
           Children.map(children, (childId, index) => {
@@ -103,10 +120,7 @@ const BeaglePageView: FC<BeaglePageViewInterface> = ({
           })
         }
       </StyleContentItems>
-
-      <StyledRightArrow onClick={nextSlide}>
-        <KeyBoardArrow />
-      </StyledRightArrow>
+      {rightArrow}
       {bullets}
     </StyledBeaglePageView>
   )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-angular/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
As pageview will be used to simulate a tabview behavior, the arrows can't be always shown. Therefore, we added an optional prop `showArrow` that will be used to hide the arrows to support the cases where the pageview is together with the tabBar

**- How I did it**
Add optional prop in interface and component

**- How to verify it**
Playground examples. Both, tabbar and pageview should be render correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add show arrow prop
