### PR TITLE
Destroys the beagle view when the component gets destroyed

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -62,7 +62,10 @@ const BeagleRemoteView: FC<BeagleRemoteViewType> = (loadParams: BeagleRemoteView
   useEffect(() => {
     beagleService.viewContentManagerMap.register(`${viewID}`, beagleView)
     loadParams.onCreateBeagleView && loadParams.onCreateBeagleView(beagleView)
-    return () => beagleService.viewContentManagerMap.unregister(`${viewID}`)
+    return () => {
+      beagleService.viewContentManagerMap.unregister(`${viewID}`)
+      beagleView.destroy()
+    }
   }, [])
 
   const renderComponents = () => {


### PR DESCRIPTION
Restates the changes done by #118 by @carolinegoncalveszup . The PR description has been copied below: 

Depends on https://github.com/ZupIT/beagle-web-core/pull/213

**- What I did**
Add calling view.destroy() when destroying the component so that unsubscriptions can be called.

**- How I did it**
Call the destroy function implemented in beagleView in core

**- How to verify it**
Running locally the playground example in `/#/cloud/309d3b74a1654dd8a2cf1da53f5d5640/global-context.json` should still update the view with the new global context values. The poc in https://github.com/ZupIT/beagle-creator/tree/react/component-interaction-global-context should work without warnings. The flow to check is: click the first button on the home page (reactive text button), it will redirect you to a view with a global context example, click on the button to set the global context using setContext action. Using the browser back button, go back to the previous home view. In this view, click again on the same button (the first one) and go to the global context example again. All this flow should happen without warning.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Call view.destroy when destroying component
