### PR TITLE
Feature/listview key

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'import'],
   rules: {
     'prettier/prettier': 'off',
-    curly: ["error", "multi"],
+    curly: 'off',
     'max-len': ['error', { code: 100, ignorePattern: maxLengthIgnorePattern }],
     'arrow-body-style': ["error", "as-needed"],
     'eol-last': ['error', 'always'],

--- a/src/components/BeagleButton/index.tsx
+++ b/src/components/BeagleButton/index.tsx
@@ -26,6 +26,7 @@ export interface BeagleButtonInterface extends BeagleDefaultComponent, BeagleCom
 	text: string,
   onPress?: () => void,
   clickAnalyticsEvent?: ClickEvent,
+  disabled?: boolean,
 }
 
 const BeagleButton: FC<BeagleButtonInterface> = ({
@@ -35,6 +36,7 @@ const BeagleButton: FC<BeagleButtonInterface> = ({
   style,
   beagleContext,
   clickAnalyticsEvent,
+  disabled,
 }) => {
   const beagleService = useContext(BeagleServiceContext)
   const element = beagleContext.getElement()
@@ -53,7 +55,13 @@ const BeagleButton: FC<BeagleButtonInterface> = ({
   }
 
   return (
-    <StyledButton style={style} className={className} onClick={handlePress} type={type}>
+    <StyledButton
+      style={style}
+      className={className}
+      onClick={handlePress}
+      type={type}
+      disabled={disabled}
+    >
       {text}
     </StyledButton>
   )

--- a/src/components/BeagleButton/styled.ts
+++ b/src/components/BeagleButton/styled.ts
@@ -39,4 +39,8 @@ export const StyledButton = styled.button`
   &:hover {
     background-color: ${BeagleTheme.swampTransparent};
   }
+  &:disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
 `

--- a/src/components/BeagleContainer/index.tsx
+++ b/src/components/BeagleContainer/index.tsx
@@ -42,7 +42,7 @@ const BeagleContainer: FC<BeagleContainerInterface> = props => {
   }, [])
 
   return (
-    <StyledContainer className={`${className} container`} style={style}>
+    <StyledContainer className={className} style={style}>
       {children}
     </StyledContainer>
   )

--- a/src/components/BeagleContainer/styled.ts
+++ b/src/components/BeagleContainer/styled.ts
@@ -19,6 +19,5 @@ import styled from 'styled-components'
 export const StyledContainer = styled.div`
 	display: flex;
   flex-direction: column;
-  overflow: auto;
   flex-wrap: wrap;
 `

--- a/src/components/BeagleContainer/styled.ts
+++ b/src/components/BeagleContainer/styled.ts
@@ -19,5 +19,4 @@ import styled from 'styled-components'
 export const StyledContainer = styled.div`
 	display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
 `

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -14,7 +14,7 @@
   * limitations under the License.
 */
 
-import React, { FC, useEffect, useRef } from 'react'
+import React, { FC, useEffect, useRef, Children } from 'react'
 import { BeagleUIElement } from '@zup-it/beagle-web'
 import { Tree } from '@zup-it/beagle-web'
 import withTheme from '../utils/withTheme'
@@ -37,9 +37,9 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
   useParentScroll = false,
 }) => {
   const elementRef = useRef() as React.MutableRefObject<HTMLDivElement>
-  const { allowOnScrollEnd } = useScroll(
+  useScroll(
     { elementRef, direction, onScrollEnd, scrollEndThreshold, useParentScroll },
-    [children],
+    [Children.count(children)],
   )
 
   useEffect(() => {
@@ -59,7 +59,6 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
     })
 
     beagleContext.getView().getRenderer().doFullRender(element, element.id)
-    allowOnScrollEnd()
   }, [JSON.stringify(dataSource)])
 
   return (

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -37,8 +37,9 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
   useParentScroll = false,
 }) => {
   const elementRef = useRef() as React.MutableRefObject<HTMLDivElement>
+  const hasRendered = !Array.isArray(dataSource) || dataSource.length === Children.count(children)
   useScroll(
-    { elementRef, direction, onScrollEnd, scrollEndThreshold, useParentScroll },
+    { elementRef, direction, onScrollEnd, scrollEndThreshold, useParentScroll, hasRendered },
     [Children.count(children)],
   )
 

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -54,7 +54,7 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
     element.children = dataSource.map((item, index) => {
       const child = Tree.clone(template)
       child._implicitContexts_ = [{ id: iteratorName, value: item }]
-      child.id = `${beagleContext.getElement().id}_${index}`
+      child.id = child.id || `${beagleContext.getElement().id}_${index}`
       return child
     })
 

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -14,26 +14,13 @@
   * limitations under the License.
 */
 
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useEffect, useRef } from 'react'
 import { BeagleUIElement } from '@zup-it/beagle-web'
-import Expression from '@zup-it/beagle-web/beagle-view/render/expression'
 import { Tree } from '@zup-it/beagle-web'
-import { BeagleComponent } from '../../types'
-import { Direction, BeagleDefaultComponent } from '../types'
 import withTheme from '../utils/withTheme'
+import useScroll from './scroll'
 import { StyledListView } from './styled'
-
-export type NodeType = HTMLElement | null
-
-export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleComponent {
-  direction: Direction,
-  dataSource: any[],
-  onInit?: () => void,
-  onScrollEnd?: () => void,
-  scrollEndThreshold?: number,
-  template: BeagleUIElement,
-  useParentScroll?: boolean,
-}
+import { BeagleListViewInterface } from './types'
 
 const BeagleListView: FC<BeagleListViewInterface> = ({
   direction = 'VERTICAL',
@@ -44,58 +31,16 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
   onScrollEnd,
   scrollEndThreshold = 100,
   dataSource,
+  iteratorName = 'item',
   beagleContext,
   children,
   useParentScroll = false,
 }) => {
-  const allowedOnScrollRef = useRef(true)
   const elementRef = useRef() as React.MutableRefObject<HTMLDivElement>
-  let node: NodeType
-
-  const hasHorizontalScroll = (nodeElement: NodeType): boolean => {
-    if (!nodeElement) return false
-
-    const overflowX = getComputedStyle(nodeElement).overflowX
-
-    const hasXScroll = overflowX !== 'visible' && overflowX !== 'hidden'
-
-    return (nodeElement.clientWidth === 0 ||
-      nodeElement.scrollWidth <= nodeElement.clientWidth ||
-      !hasXScroll)
-  }
-
-  const hasVerticalScroll = (nodeElement: NodeType): boolean => {
-    if (!nodeElement) return false
-
-    const overflowY = getComputedStyle(nodeElement).overflowY
-    const hasYScroll = overflowY !== 'visible' && overflowY !== 'hidden'
-    return (nodeElement.clientHeight === 0 ||
-      nodeElement.scrollHeight <= nodeElement.clientHeight ||
-      !hasYScroll)
-  }
-
-  const getParentNode = (nodeElement: NodeType): NodeType => {
-    if (!nodeElement) return null
-    if (nodeElement.nodeName === 'HTML') return nodeElement
-
-    if (direction === 'VERTICAL' && hasVerticalScroll(nodeElement) ||
-      direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
-      return getParentNode(nodeElement.parentNode as HTMLElement)
-
-    return nodeElement
-  }
-
-  const getReferenceNode = (): NodeType => {
-    if (!elementRef || !elementRef.current)
-      return null
-
-    if (useParentScroll) {
-      let parentNode = elementRef.current.parentNode as NodeType
-      parentNode = getParentNode(parentNode)
-      return parentNode as NodeType
-    }
-    return (elementRef.current as NodeType)
-  }
+  const { allowOnScrollEnd } = useScroll(
+    { elementRef, direction, onScrollEnd, scrollEndThreshold, useParentScroll },
+    [children],
+  )
 
   useEffect(() => {
     if (onInit) onInit()
@@ -106,59 +51,25 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
     const element = beagleContext.getElement() as BeagleUIElement
     if (!element) return
 
-    element.children = dataSource.map((item) => {
+    element.children = dataSource.map((item, index) => {
       const child = Tree.clone(template)
-      return Tree.replaceEach(child, component => (
-        Expression.resolveForComponent(component, [{ id: 'item', value: item }])
-      ))
+      child._implicitContexts_ = [{ id: iteratorName, value: item }]
+      child.id = `${beagleContext.getElement().id}_${index}`
+      return child
     })
 
     beagleContext.getView().getRenderer().doFullRender(element, element.id)
-    allowedOnScrollRef.current = true
-
+    allowOnScrollEnd()
   }, [JSON.stringify(dataSource)])
 
-  const callOnScrollEnd = () => onScrollEnd && onScrollEnd()
-
-  const calcPercentage = () => {
-    if (!node) return
-
-    let screenPercentage: number
-    if (direction === 'VERTICAL') {
-      const scrollPosition = node.scrollTop
-      screenPercentage = (scrollPosition /
-        (node.scrollHeight - node.clientHeight)) * 100
-    } else {
-      const scrollPosition = node.scrollLeft
-      screenPercentage = (scrollPosition /
-        (node.scrollWidth - node.clientWidth)) * 100
-    }
-    
-    if (scrollEndThreshold && Math.ceil(screenPercentage) >= scrollEndThreshold
-      && allowedOnScrollRef.current) {
-      allowedOnScrollRef.current = false
-      callOnScrollEnd()
-    }
-  }
-
-  useEffect(() => {
-    const referenceNode = getReferenceNode()
-    if (referenceNode !== node) {
-      if (node !== undefined && node !== null) node.removeEventListener('scroll', calcPercentage)
-      node = referenceNode
-
-      const parent = (node && node.nodeName !== 'HTML')
-        ? node : window
-
-      parent.addEventListener('scroll', calcPercentage)
-      return () => parent.removeEventListener('scroll', calcPercentage)
-    }
-  }, [children])
-
   return (
-    <StyledListView ref={elementRef}
-      className={className} direction={direction}
-      useParentScroll={useParentScroll} style={style}>
+    <StyledListView
+      ref={elementRef}
+      className={className}
+      direction={direction}
+      useParentScroll={useParentScroll}
+      style={style}
+    >
       {children}
     </StyledListView>
   )

--- a/src/components/BeagleFutureListView/scroll.ts
+++ b/src/components/BeagleFutureListView/scroll.ts
@@ -1,0 +1,113 @@
+/*
+  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+
+import { useEffect, useRef } from 'react'
+import { ScrollInterface, NodeType } from './types'
+
+function useScroll(props: ScrollInterface, deps: any[]) {
+  const { direction, onScrollEnd, scrollEndThreshold, useParentScroll, elementRef } = props
+  const allowedOnScrollRef = useRef(true)
+  
+  let node: NodeType
+
+  const hasHorizontalScroll = (nodeElement: NodeType): boolean => {
+    if (!nodeElement) return false
+
+    const overflowX = getComputedStyle(nodeElement).overflowX
+
+    const hasXScroll = overflowX !== 'visible' && overflowX !== 'hidden'
+
+    return (nodeElement.clientWidth === 0 ||
+      nodeElement.scrollWidth <= nodeElement.clientWidth ||
+      !hasXScroll)
+  }
+
+  const hasVerticalScroll = (nodeElement: NodeType): boolean => {
+    if (!nodeElement) return false
+
+    const overflowY = getComputedStyle(nodeElement).overflowY
+    const hasYScroll = overflowY !== 'visible' && overflowY !== 'hidden'
+    return (nodeElement.clientHeight === 0 ||
+      nodeElement.scrollHeight <= nodeElement.clientHeight ||
+      !hasYScroll)
+  }
+
+  const getParentNode = (nodeElement: NodeType): NodeType => {
+    if (!nodeElement) return null
+    if (nodeElement.nodeName === 'HTML') return nodeElement
+
+    if (direction === 'VERTICAL' && hasVerticalScroll(nodeElement) ||
+      direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
+      return getParentNode(nodeElement.parentNode as HTMLElement)
+
+    return nodeElement
+  }
+
+  const getReferenceNode = (): NodeType => {
+    if (!elementRef || !elementRef.current) return null
+
+    if (useParentScroll) {
+      let parentNode = elementRef.current.parentNode as NodeType
+      parentNode = getParentNode(parentNode)
+      return parentNode as NodeType
+    }
+  
+    return (elementRef.current as NodeType)
+  }
+
+  const callOnScrollEnd = () => onScrollEnd && onScrollEnd()
+
+  const calcPercentage = () => {
+    if (!node) return
+
+    let screenPercentage: number
+    if (direction === 'VERTICAL') {
+      const scrollPosition = node.scrollTop
+      screenPercentage = (scrollPosition /
+        (node.scrollHeight - node.clientHeight)) * 100
+    } else {
+      const scrollPosition = node.scrollLeft
+      screenPercentage = (scrollPosition /
+        (node.scrollWidth - node.clientWidth)) * 100
+    }
+    
+    if (scrollEndThreshold && Math.ceil(screenPercentage) >= scrollEndThreshold
+      && allowedOnScrollRef.current) {
+      allowedOnScrollRef.current = false
+      callOnScrollEnd()
+    }
+  }
+
+  const allowOnScrollEnd = () => allowedOnScrollRef.current = true
+
+  useEffect(() => {
+    const referenceNode = getReferenceNode()
+    if (referenceNode !== node) {
+      if (node !== undefined && node !== null) node.removeEventListener('scroll', calcPercentage)
+      node = referenceNode
+
+      const parent = (node && node.nodeName !== 'HTML')
+        ? node : window
+
+      parent.addEventListener('scroll', calcPercentage)
+      return () => parent.removeEventListener('scroll', calcPercentage)
+    }
+  }, deps)
+
+  return { allowOnScrollEnd }
+}
+
+export default useScroll

--- a/src/components/BeagleFutureListView/scroll.ts
+++ b/src/components/BeagleFutureListView/scroll.ts
@@ -18,8 +18,15 @@ import { useEffect, useRef } from 'react'
 import { ScrollInterface, NodeType } from './types'
 
 function useScroll(props: ScrollInterface, deps: any[]) {
-  const { direction, onScrollEnd, scrollEndThreshold, useParentScroll, elementRef } = props
   const allowedOnScrollRef = useRef(true)
+  const {
+    direction,
+    onScrollEnd,
+    scrollEndThreshold,
+    useParentScroll,
+    elementRef,
+    hasRendered,
+  } = props
   
   let node: NodeType
 
@@ -98,6 +105,7 @@ function useScroll(props: ScrollInterface, deps: any[]) {
   )
 
   useEffect(() => {
+    if (!hasRendered) return
     allowedOnScrollRef.current = true
     const referenceNode = getReferenceNode()
     if (referenceNode !== node) {

--- a/src/components/BeagleFutureListView/types.ts
+++ b/src/components/BeagleFutureListView/types.ts
@@ -14,18 +14,27 @@
   * limitations under the License.
 */
 
-import styled from 'styled-components'
-import { Direction } from '../types'
+import { BeagleUIElement } from '@zup-it/beagle-web'
+import { BeagleComponent } from '../../types'
+import { Direction, BeagleDefaultComponent } from '../types'
 
-interface StyledListViewInterface {
+export type NodeType = HTMLElement | null
+
+export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleComponent {
   direction: Direction,
+  dataSource: any[],
+  iteratorName?: string,
+  onInit?: () => void,
+  onScrollEnd?: () => void,
+  scrollEndThreshold?: number,
+  template: BeagleUIElement,
   useParentScroll?: boolean,
 }
 
-export const StyledListView = styled.div<StyledListViewInterface>`
-  display: flex;
-  flex-direction: ${({ direction }) => direction === 'VERTICAL' ? 'column' : 'row'};
-  overflow: ${({ useParentScroll }) => useParentScroll ? 'inherit' : 'auto'};
-  width: ${({ direction }) => direction === 'HORIZONTAL' ? '100%' : 'auto'};
-  height: ${({ direction }) => direction === 'VERTICAL' ? '100%' : 'auto'};
-`
+export interface ScrollInterface {
+  direction: Direction,
+  onScrollEnd?: () => void,
+  scrollEndThreshold: number,
+  useParentScroll: boolean,
+  elementRef: React.MutableRefObject<HTMLDivElement>,
+}

--- a/src/components/BeagleFutureListView/types.ts
+++ b/src/components/BeagleFutureListView/types.ts
@@ -37,4 +37,5 @@ export interface ScrollInterface {
   scrollEndThreshold: number,
   useParentScroll: boolean,
   elementRef: React.MutableRefObject<HTMLDivElement>,
+  hasRendered: boolean,
 }

--- a/src/components/BeagleFutureListView/types.ts
+++ b/src/components/BeagleFutureListView/types.ts
@@ -29,6 +29,10 @@ export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleC
   scrollEndThreshold?: number,
   template: BeagleUIElement,
   useParentScroll?: boolean,
+  /* the property "key" is not allowed in React. Since this is not a rule for Beagle, every time
+  Beagle receives "key", it transforms it into "_key" */
+  _key?: string,
+  __suffix__?: string,
 }
 
 export interface ScrollInterface {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -27,6 +27,13 @@ const createReactComponentTree = <Schema>(
   viewId: string,
   contentManagerMap: ViewContentManagerMap,
 ): JSX.Element => {
+  /* the property "key" is not allowed in React. Since this is not a rule for Beagle, every time
+  Beagle receives "key", it transforms it into "_key" */
+  if (ui.key) {
+    ui._key = ui.key
+    delete ui.key
+  }
+  
   const { _beagleComponent_, children, id, context, ...props } = ui
   
   if (!_beagleComponent_) return createElement(Fragment)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
**DEPENDS ON #126**

- Create id's correctly for child elements in a template. Was randomizing in every render.
- Calculates id's according to the property "key" of the list view.
- Correctly and consistently assigns ids for components inside nested list views.
- Since "key" is forbidden in react, every time Beagle uses the prop "key", we convert it to "_key".

**- How I did it**
Used the new prop "key" and created a new internal prop "__suffix__" to keep track of nested list view ids.

**- How to verify it**
Playground. In a pagination example, now the "onInit" action will run for every page if "key" is correctly specified.

**- Description for the changelog**
Added "key" to the list view and fixed id assignment
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
