### PR TITLE
Fix/beagle context name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@
   * limitations under the License.
 */
 
-const singleLineString = `^\\s*[^\\s]*'([^']|(\\\\'))*',?;?$`
+const singleLineString = `^\\s*[^']*'([^']|(\\\\'))*'\\)*,?;?$`
 const doubleQuoted = singleLineString.replace(/'/g, '"')
 const template = singleLineString.replace(/'/g, '`')
 
@@ -32,7 +32,7 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'import'],
   rules: {
     'prettier/prettier': 'off',
-    curly: ["error", "multi"],
+    curly: 'off',
     'max-len': ['error', { code: 100, ignorePattern: maxLengthIgnorePattern }],
     'arrow-body-style': ["error", "as-needed"],
     'eol-last': ['error', 'always'],

--- a/src/components/BeagleButton/index.tsx
+++ b/src/components/BeagleButton/index.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { FC, useContext } from 'react'
-import { ClickEvent } from '@zup-it/beagle-web'
+import { ClickEvent, ViewContentManager } from '@zup-it/beagle-web'
 import BeagleServiceContext from '../../provider'
 import { BeagleComponent } from '../../types'
 import { BeagleDefaultComponent } from '../types'
@@ -28,28 +28,29 @@ export interface BeagleButtonInterface extends BeagleDefaultComponent, BeagleCom
   clickAnalyticsEvent?: ClickEvent,
 }
 
+function isSubmitButton(contentManager?: ViewContentManager) {
+  if (!contentManager) return false
+  const element = contentManager.getElement()
+  return element.onPress && element.onPress._beagleAction_ === 'beagle:submitForm'
+}
+
 const BeagleButton: FC<BeagleButtonInterface> = ({
   text,
   className,
   onPress,
   style,
-  beagleContext,
+  viewContentManager,
   clickAnalyticsEvent,
 }) => {
   const beagleService = useContext(BeagleServiceContext)
-  const element = beagleContext.getElement()
-  const isSubmitButton = (
-    element
-    && element.onPress
-    && element.onPress._beagleAction_ === 'beagle:submitForm'
-  )
+  const isSubmit = isSubmitButton(viewContentManager)
   const beagleAnalytics = beagleService && beagleService.analytics
-  const type = isSubmitButton ? 'submit' : 'button'
+  const type = isSubmit ? 'submit' : 'button'
   const handlePress = () => {
     if (clickAnalyticsEvent && beagleAnalytics)
       beagleAnalytics.trackEventOnClick(clickAnalyticsEvent)
 
-    return isSubmitButton ? undefined : onPress && onPress()
+    return isSubmit ? undefined : onPress && onPress()
   }
 
   return (

--- a/src/components/BeagleButton/index.tsx
+++ b/src/components/BeagleButton/index.tsx
@@ -26,6 +26,7 @@ export interface BeagleButtonInterface extends BeagleDefaultComponent, BeagleCom
 	text: string,
   onPress?: () => void,
   clickAnalyticsEvent?: ClickEvent,
+  disabled?: boolean,
 }
 
 function isSubmitButton(contentManager?: ViewContentManager) {
@@ -41,6 +42,7 @@ const BeagleButton: FC<BeagleButtonInterface> = ({
   style,
   viewContentManager,
   clickAnalyticsEvent,
+  disabled,
 }) => {
   const beagleService = useContext(BeagleServiceContext)
   const isSubmit = isSubmitButton(viewContentManager)
@@ -54,7 +56,13 @@ const BeagleButton: FC<BeagleButtonInterface> = ({
   }
 
   return (
-    <StyledButton style={style} className={className} onClick={handlePress} type={type}>
+    <StyledButton
+      style={style}
+      className={className}
+      onClick={handlePress}
+      type={type}
+      disabled={disabled}
+    >
       {text}
     </StyledButton>
   )

--- a/src/components/BeagleButton/styled.ts
+++ b/src/components/BeagleButton/styled.ts
@@ -39,4 +39,8 @@ export const StyledButton = styled.button`
   &:hover {
     background-color: ${BeagleTheme.swampTransparent};
   }
+  &:disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
 `

--- a/src/components/BeagleContainer/index.tsx
+++ b/src/components/BeagleContainer/index.tsx
@@ -42,7 +42,7 @@ const BeagleContainer: FC<BeagleContainerInterface> = props => {
   }, [])
 
   return (
-    <StyledContainer className={`${className} container`} style={style}>
+    <StyledContainer className={className} style={style}>
       {children}
     </StyledContainer>
   )

--- a/src/components/BeagleContainer/styled.ts
+++ b/src/components/BeagleContainer/styled.ts
@@ -19,6 +19,4 @@ import styled from 'styled-components'
 export const StyledContainer = styled.div`
 	display: flex;
   flex-direction: column;
-  overflow: auto;
-  flex-wrap: wrap;
 `

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -14,26 +14,13 @@
   * limitations under the License.
 */
 
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useEffect, useRef, Children } from 'react'
 import { BeagleUIElement } from '@zup-it/beagle-web'
-import Expression from '@zup-it/beagle-web/beagle-view/render/expression'
 import { Tree } from '@zup-it/beagle-web'
-import { BeagleComponent } from '../../types'
-import { Direction, BeagleDefaultComponent } from '../types'
 import withTheme from '../utils/withTheme'
+import useScroll from './scroll'
 import { StyledListView } from './styled'
-
-export type NodeType = HTMLElement | null
-
-export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleComponent {
-  direction: Direction,
-  dataSource: any[],
-  onInit?: () => void,
-  onScrollEnd?: () => void,
-  scrollEndThreshold?: number,
-  template: BeagleUIElement,
-  useParentScroll?: boolean,
-}
+import { BeagleListViewInterface } from './types'
 
 const BeagleListView: FC<BeagleListViewInterface> = ({
   direction = 'VERTICAL',
@@ -44,58 +31,17 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
   onScrollEnd,
   scrollEndThreshold = 100,
   dataSource,
+  iteratorName = 'item',
   beagleContext,
   children,
   useParentScroll = false,
 }) => {
-  const allowedOnScrollRef = useRef(true)
   const elementRef = useRef() as React.MutableRefObject<HTMLDivElement>
-  let node: NodeType
-
-  const hasHorizontalScroll = (nodeElement: NodeType): boolean => {
-    if (!nodeElement) return false
-
-    const overflowX = getComputedStyle(nodeElement).overflowX
-
-    const hasXScroll = overflowX !== 'visible' && overflowX !== 'hidden'
-
-    return (nodeElement.clientWidth === 0 ||
-      nodeElement.scrollWidth <= nodeElement.clientWidth ||
-      !hasXScroll)
-  }
-
-  const hasVerticalScroll = (nodeElement: NodeType): boolean => {
-    if (!nodeElement) return false
-
-    const overflowY = getComputedStyle(nodeElement).overflowY
-    const hasYScroll = overflowY !== 'visible' && overflowY !== 'hidden'
-    return (nodeElement.clientHeight === 0 ||
-      nodeElement.scrollHeight <= nodeElement.clientHeight ||
-      !hasYScroll)
-  }
-
-  const getParentNode = (nodeElement: NodeType): NodeType => {
-    if (!nodeElement) return null
-    if (nodeElement.nodeName === 'HTML') return nodeElement
-
-    if (direction === 'VERTICAL' && hasVerticalScroll(nodeElement) ||
-      direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
-      return getParentNode(nodeElement.parentNode as HTMLElement)
-
-    return nodeElement
-  }
-
-  const getReferenceNode = (): NodeType => {
-    if (!elementRef || !elementRef.current)
-      return null
-
-    if (useParentScroll) {
-      let parentNode = elementRef.current.parentNode as NodeType
-      parentNode = getParentNode(parentNode)
-      return parentNode as NodeType
-    }
-    return (elementRef.current as NodeType)
-  }
+  const hasRendered = !Array.isArray(dataSource) || dataSource.length === Children.count(children)
+  useScroll(
+    { elementRef, direction, onScrollEnd, scrollEndThreshold, useParentScroll, hasRendered },
+    [Children.count(children)],
+  )
 
   useEffect(() => {
     if (onInit) onInit()
@@ -106,59 +52,24 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
     const element = beagleContext.getElement() as BeagleUIElement
     if (!element) return
 
-    element.children = dataSource.map((item) => {
+    element.children = dataSource.map((item, index) => {
       const child = Tree.clone(template)
-      return Tree.replaceEach(child, component => (
-        Expression.resolveForComponent(component, [{ id: 'item', value: item }])
-      ))
+      child._implicitContexts_ = [{ id: iteratorName, value: item }]
+      child.id = child.id || `${beagleContext.getElement().id}_${index}`
+      return child
     })
 
     beagleContext.getView().getRenderer().doFullRender(element, element.id)
-    allowedOnScrollRef.current = true
-
   }, [JSON.stringify(dataSource)])
 
-  const callOnScrollEnd = () => onScrollEnd && onScrollEnd()
-
-  const calcPercentage = () => {
-    if (!node) return
-
-    let screenPercentage: number
-    if (direction === 'VERTICAL') {
-      const scrollPosition = node.scrollTop
-      screenPercentage = (scrollPosition /
-        (node.scrollHeight - node.clientHeight)) * 100
-    } else {
-      const scrollPosition = node.scrollLeft
-      screenPercentage = (scrollPosition /
-        (node.scrollWidth - node.clientWidth)) * 100
-    }
-    
-    if (scrollEndThreshold && Math.ceil(screenPercentage) >= scrollEndThreshold
-      && allowedOnScrollRef.current) {
-      allowedOnScrollRef.current = false
-      callOnScrollEnd()
-    }
-  }
-
-  useEffect(() => {
-    const referenceNode = getReferenceNode()
-    if (referenceNode !== node) {
-      if (node !== undefined && node !== null) node.removeEventListener('scroll', calcPercentage)
-      node = referenceNode
-
-      const parent = (node && node.nodeName !== 'HTML')
-        ? node : window
-
-      parent.addEventListener('scroll', calcPercentage)
-      return () => parent.removeEventListener('scroll', calcPercentage)
-    }
-  }, [children])
-
   return (
-    <StyledListView ref={elementRef}
-      className={className} direction={direction}
-      useParentScroll={useParentScroll} style={style}>
+    <StyledListView
+      ref={elementRef}
+      className={className}
+      direction={direction}
+      useParentScroll={useParentScroll}
+      style={style}
+    >
       {children}
     </StyledListView>
   )

--- a/src/components/BeagleFutureListView/index.tsx
+++ b/src/components/BeagleFutureListView/index.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC, useEffect, useRef, Children } from 'react'
 import { BeagleUIElement } from '@zup-it/beagle-web'
-import { Tree } from '@zup-it/beagle-web'
+import { Tree, logger } from '@zup-it/beagle-web'
 import withTheme from '../utils/withTheme'
 import useScroll from './scroll'
 import { StyledListView } from './styled'
@@ -32,7 +32,7 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
   scrollEndThreshold = 100,
   dataSource,
   iteratorName = 'item',
-  beagleContext,
+  viewContentManager,
   children,
   useParentScroll = false,
 }) => {
@@ -49,17 +49,21 @@ const BeagleListView: FC<BeagleListViewInterface> = ({
 
   useEffect(() => {
     if (!Array.isArray(dataSource)) return
-    const element = beagleContext.getElement() as BeagleUIElement
-    if (!element) return
+
+    if (!viewContentManager) {
+      return logger.error('The beagle:listview component should only be used inside a view rendered by Beagle.')
+    }
+
+    const element = viewContentManager.getElement() as BeagleUIElement
 
     element.children = dataSource.map((item, index) => {
       const child = Tree.clone(template)
       child._implicitContexts_ = [{ id: iteratorName, value: item }]
-      child.id = child.id || `${beagleContext.getElement().id}_${index}`
+      child.id = child.id || `${viewContentManager.getElement().id}_${index}`
       return child
     })
 
-    beagleContext.getView().getRenderer().doFullRender(element, element.id)
+    viewContentManager.getView().getRenderer().doFullRender(element, element.id)
   }, [JSON.stringify(dataSource)])
 
   return (

--- a/src/components/BeagleFutureListView/scroll.ts
+++ b/src/components/BeagleFutureListView/scroll.ts
@@ -1,0 +1,125 @@
+/*
+  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+
+import { useEffect, useRef } from 'react'
+import { ScrollInterface, NodeType } from './types'
+
+function useScroll(props: ScrollInterface, deps: any[]) {
+  const allowedOnScrollRef = useRef(true)
+  const {
+    direction,
+    onScrollEnd,
+    scrollEndThreshold,
+    useParentScroll,
+    elementRef,
+    hasRendered,
+  } = props
+  
+  let node: NodeType
+
+  const hasHorizontalScroll = (nodeElement: NodeType): boolean => {
+    if (!nodeElement) return false
+
+    const overflowX = getComputedStyle(nodeElement).overflowX
+
+    const hasXScroll = overflowX !== 'visible' && overflowX !== 'hidden'
+
+    return (nodeElement.clientWidth === 0 ||
+      nodeElement.scrollWidth <= nodeElement.clientWidth ||
+      !hasXScroll)
+  }
+
+  const hasVerticalScroll = (nodeElement: NodeType): boolean => {
+    if (!nodeElement) return false
+
+    const overflowY = getComputedStyle(nodeElement).overflowY
+    const hasYScroll = overflowY !== 'visible' && overflowY !== 'hidden'
+    return (nodeElement.clientHeight === 0 ||
+      nodeElement.scrollHeight <= nodeElement.clientHeight ||
+      !hasYScroll)
+  }
+
+  const getParentNode = (nodeElement: NodeType): NodeType => {
+    if (!nodeElement) return null
+    if (nodeElement.nodeName === 'HTML') return nodeElement
+
+    if (direction === 'VERTICAL' && hasVerticalScroll(nodeElement) ||
+      direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
+      return getParentNode(nodeElement.parentNode as HTMLElement)
+
+    return nodeElement
+  }
+
+  const getReferenceNode = (): NodeType => {
+    if (!elementRef || !elementRef.current) return null
+
+    if (useParentScroll) {
+      let parentNode = elementRef.current.parentNode as NodeType
+      parentNode = getParentNode(parentNode)
+      return parentNode as NodeType
+    }
+  
+    return (elementRef.current as NodeType)
+  }
+
+  const callOnScrollEnd = () => {
+    if (allowedOnScrollRef.current && onScrollEnd) onScrollEnd()
+    allowedOnScrollRef.current = false
+  }
+
+  const calcPercentage = () => {
+    if (!node) return
+
+    let screenPercentage: number
+    if (direction === 'VERTICAL') {
+      const scrollPosition = node.scrollTop
+      screenPercentage = (scrollPosition /
+        (node.scrollHeight - node.clientHeight)) * 100
+    } else {
+      const scrollPosition = node.scrollLeft
+      screenPercentage = (scrollPosition /
+        (node.scrollWidth - node.clientWidth)) * 100
+    }
+
+    const isOverThreshold = scrollEndThreshold && Math.ceil(screenPercentage) >= scrollEndThreshold
+    if (isOverThreshold) callOnScrollEnd()
+  }
+
+  const canScrollContent = (element: HTMLElement) => (
+    direction === 'HORIZONTAL'
+      ? element.scrollWidth > element.clientWidth
+      : element.scrollHeight > element.clientHeight
+  )
+
+  useEffect(() => {
+    if (!hasRendered) return
+    allowedOnScrollRef.current = true
+    const referenceNode = getReferenceNode()
+    if (referenceNode !== node) {
+      if (node !== undefined && node !== null) node.removeEventListener('scroll', calcPercentage)
+      node = referenceNode
+
+      const parent = (node && node.nodeName !== 'HTML') ? node : window
+
+      if (!canScrollContent(parent instanceof Window ? document.body : parent)) callOnScrollEnd()
+
+      parent.addEventListener('scroll', calcPercentage)
+      return () => parent.removeEventListener('scroll', calcPercentage)
+    }
+  }, deps)
+}
+
+export default useScroll

--- a/src/components/BeagleFutureListView/types.ts
+++ b/src/components/BeagleFutureListView/types.ts
@@ -14,18 +14,28 @@
   * limitations under the License.
 */
 
-import styled from 'styled-components'
-import { Direction } from '../types'
+import { BeagleUIElement } from '@zup-it/beagle-web'
+import { BeagleComponent } from '../../types'
+import { Direction, BeagleDefaultComponent } from '../types'
 
-interface StyledListViewInterface {
+export type NodeType = HTMLElement | null
+
+export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleComponent {
   direction: Direction,
+  dataSource: any[],
+  iteratorName?: string,
+  onInit?: () => void,
+  onScrollEnd?: () => void,
+  scrollEndThreshold?: number,
+  template: BeagleUIElement,
   useParentScroll?: boolean,
 }
 
-export const StyledListView = styled.div<StyledListViewInterface>`
-  display: flex;
-  flex-direction: ${({ direction }) => direction === 'VERTICAL' ? 'column' : 'row'};
-  overflow: ${({ useParentScroll }) => useParentScroll ? 'inherit' : 'auto'};
-  width: ${({ direction }) => direction === 'HORIZONTAL' ? '100%' : 'auto'};
-  height: ${({ direction }) => direction === 'VERTICAL' ? '100%' : 'auto'};
-`
+export interface ScrollInterface {
+  direction: Direction,
+  onScrollEnd?: () => void,
+  scrollEndThreshold: number,
+  useParentScroll: boolean,
+  elementRef: React.MutableRefObject<HTMLDivElement>,
+  hasRendered: boolean,
+}

--- a/src/components/BeagleLazy/index.tsx
+++ b/src/components/BeagleLazy/index.tsx
@@ -22,13 +22,13 @@ export interface BeagleLazyInterface extends BeagleComponent {
   path: string,
 }
 
-const BeagleLazy: FC<BeagleLazyInterface> = ({ path, children, beagleContext }) => {
+const BeagleLazy: FC<BeagleLazyInterface> = ({ path, children, viewContentManager }) => {
   useEffect(() => {
     const params: LoadParams = {
       path,
       shouldShowLoading: false,
     }
-    beagleContext && beagleContext.replaceComponent(params)
+    viewContentManager && viewContentManager.replaceComponent(params)
   }, [])
 
   return (

--- a/src/components/BeagleTabView/BeagleTabItem/index.tsx
+++ b/src/components/BeagleTabView/BeagleTabItem/index.tsx
@@ -32,8 +32,8 @@ export interface BeagleTabItemInterface extends BeagleComponent {
 }
 
 const BeagleTabItem: FC<BeagleTabItemInterface> = props => {
-  const { title, icon, beagleContext, children } = props
-  const id = beagleContext.getElementId()
+  const { title, icon, viewContentManager, children } = props
+  const id = viewContentManager ? viewContentManager.getElementId() : ''
   const componentsService = useContext(tabContext)
 
   return (

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -40,10 +40,10 @@ const createReactComponentTree = <Schema>(
     return createElement(Fragment)
   }
 
-  const beagleContext = contentManagerMap.get(viewId, id)
+  const viewContentManager = contentManagerMap.get(viewId, id)
   const componentChildren = map(children, child =>
     createReactComponentTree(components, child, viewId, contentManagerMap))
-  const componentProps = { ...props, key: id, beagleContext }
+  const componentProps = { ...props, key: id, viewContentManager }
 
   return createElement(BeagleId, { id, key: id }, [
     createElement(Component as FC<any>, componentProps, componentChildren),

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ import {
   DefaultSchema,
   DataContext,
   ErrorComponentParams,
-  ViewContentManager,
+  ViewContentManager as CoreViewContentManager,
 } from '@zup-it/beagle-web'
 
 export interface BeagleConfig<Schema = DefaultSchema> extends BeagleCoreConfig<Schema> {
@@ -37,10 +37,10 @@ export interface BeagleUIService<Schema = DefaultSchema> extends BeagleCoreServi
   getConfig: () => BeagleConfig<Schema>,
 }
 
-export type BeagleContext = ViewContentManager
+export type ViewContentManager = CoreViewContentManager
 
 export interface BeagleComponent {
-  beagleContext: BeagleContext,
+  viewContentManager?: ViewContentManager,
 }
 
 export { DataContext }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
**Depends on #126**

- Changed "BeagleContext" to "ViewContentManager".
- To avoid making beagle specific properties required, "ViewContentManager" is optional and inside the component it is mandatory to verify if it is available. This is important because the componentes should be also usable outside the context of Beagle.

**- How I did it**
Renamed BeagleContext to ViewContentManager and made all necessary adjustments.

**- How to verify it**
Playground examples are still working

**- Description for the changelog**
BeagleContext is now ViewContentmanager