### PR TITLE
fixing lazy component

### DIFF
--- a/packages/beagle-react/src/components/BeagleLazy/index.tsx
+++ b/packages/beagle-react/src/components/BeagleLazy/index.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { FC, useEffect } from 'react'
-import { LoadParams } from '@zup-it/beagle-web'
+import { LoadParams, BeagleChildren } from '@zup-it/beagle-web'
 import { BeagleComponent } from 'common/types'
 
 export interface BeagleLazyInterface extends BeagleComponent {
@@ -41,5 +41,7 @@ const BeagleLazy: FC<BeagleLazyInterface> = ({ path, children, viewContentManage
     </div>
   )
 }
+
+BeagleChildren({ property: 'initialState' })(BeagleLazy)
 
 export default BeagleLazy

--- a/packages/beagle-react/src/components/BeagleLazy/index.tsx
+++ b/packages/beagle-react/src/components/BeagleLazy/index.tsx
@@ -28,7 +28,11 @@ const BeagleLazy: FC<BeagleLazyInterface> = ({ path, children, viewContentManage
       path,
       shouldShowLoading: false,
     }
-    viewContentManager && viewContentManager.replaceComponent(params)
+    viewContentManager && viewContentManager.getView().fetch(
+      params,
+      viewContentManager.getElementId(),
+      'replaceComponent',
+    )
   }, [])
 
   return (

--- a/packages/beagle-react/src/components/BeagleTabBar/index.tsx
+++ b/packages/beagle-react/src/components/BeagleTabBar/index.tsx
@@ -15,9 +15,11 @@
 */
 
 import React, { FC } from 'react'
+import { BeforeViewSnapshot } from '@zup-it/beagle-web'
 import { BeagleDefaultComponent } from '../types'
 import withTheme from '../utils/withTheme'
 import { ImagePath } from '../BeagleImage'
+import { transformItems } from './lifecycles'
 import {
   StyledTabBar,
   StyledBeagleTabItem,
@@ -39,7 +41,6 @@ export interface BeagleTabBarInterface extends BeagleDefaultComponent {
 }
 
 const BeagleTabBar: FC<BeagleTabBarInterface> = ({ onTabSelection, currentTab, items }) => {
-
   const changeSelectedTab = (index: number) => {
     if (!onTabSelection) return
     onTabSelection(index)
@@ -63,5 +64,7 @@ const BeagleTabBar: FC<BeagleTabBarInterface> = ({ onTabSelection, currentTab, i
     </StyledTabBar>
   )
 }
+
+BeforeViewSnapshot(transformItems)(BeagleTabBar)
 
 export default withTheme(BeagleTabBar)

--- a/packages/beagle-react/src/components/BeagleTabBar/lifecycles.ts
+++ b/packages/beagle-react/src/components/BeagleTabBar/lifecycles.ts
@@ -1,0 +1,24 @@
+/*
+  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+
+export function transformItems(tabBar: Record<string, any>) {
+  if (!Array.isArray(tabBar.items)) return
+  tabBar.children = tabBar.items.map(item => ({
+    _beagleComponent_: 'beagle:tabitem',
+    id: `${tabBar.id}_${item.title}`,
+    ...item,
+  }))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Depends on https://github.com/ZupIT/beagle-web-core/pull/234

Removes the usage of `replaceComponent` in the LazyComponent. This shortcut method doesn't exist anymore. The reasons are explained in https://github.com/ZupIT/beagle-web-core/pull/234.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
