### PR TITLE
Prettier sugestion with eslint alteration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
     'keyword-spacing': ["error", { before: true, after: true }],
     'array-bracket-spacing': ['error', 'never'],
     'object-curly-spacing': ['error', 'always'],
-    
+
     'import/prefer-default-export': 0,
     'import/no-extraneous-dependencies': 'off',
     'import/order': ['warn', {
@@ -57,15 +57,12 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'off',
     'react/require-default-props': 'off',
     'react/prop-types': 'off',
-    
+
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
-    '@typescript-eslint/member-delimiter-style': ['error', {
-      multiline: { delimiter: 'comma', requireLast: true },
-      singleline: { delimiter: 'comma', requireLast: false }
-    }],
+    '@typescript-eslint/member-delimiter-style': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
   },
   "settings": {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "jsxBracketSameLine": true,
+  "jsxSingleQuote": true,
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "publish": "lerna publish from-package",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "format-code": "prettier --write \"./**/*.{ts, tsx, js, jsx, json}\"",
     "clean": "lerna run clean",
     "check-types": "lerna run check-types",
     "build": "lerna run build",

--- a/packages/beagle-react-native/src/components/index.ts
+++ b/packages/beagle-react-native/src/components/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import BeagleText from './BeagleText'
 import BeagleError from './BeagleError'
@@ -33,8 +33,6 @@ import BeagleSimpleForm from './BeagleSimpleForm'
 import BeagleWebView from './BeagleWebView'
 import BeagleFutureListView from './BeagleFutureListView'
 
-
-
 const libRequiredComponents = {
   'custom:error': BeagleError,
   'custom:loading': BeagleLoading,
@@ -54,11 +52,10 @@ const beagleDefaultComponents = {
   'beagle:lazycomponent': BeagleLazy,
   'beagle:simpleform': BeagleSimpleForm,
   'beagle:webview': BeagleWebView,
-  'beagle:futurelistview':BeagleFutureListView,
+  'beagle:futurelistview': BeagleFutureListView,
   'custom:modal': BeagleModal,
   'custom:text-area': BeagleTextArea,
 }
-
 
 export default {
   ...libRequiredComponents,

--- a/packages/beagle-react-native/src/components/utils.ts
+++ b/packages/beagle-react-native/src/components/utils.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 const VALID_CSS_PROPERTIES = [
   'top',
@@ -59,12 +59,12 @@ const VALID_CSS_PROPERTIES = [
 ]
 
 export function removeInvalidCssProperties(
-  style: Record<string, any> | React.CSSProperties): Record<string, any> {
-
+  style: Record<string, any> | React.CSSProperties
+): Record<string, any> {
   if (!style) return {}
   return Object.entries({ ...style })
     .filter(([key, value]) => VALID_CSS_PROPERTIES.includes(key) && !/auto|inherit/gmi.test(value))
     .map(([key, value]) => [key, value.replace(/px/gmi, '')])
-    .map(([key, value]) => /^\d+$/.test(value) ? [key, Number(value)] : [key, value])
+    .map(([key, value]) => (/^\d+$/.test(value) ? [key, Number(value)] : [key, value]))
     .reduce((previous, [key, value]) => ({ ...previous, [key]: value }), {})
 }

--- a/packages/beagle-react-native/src/index.ts
+++ b/packages/beagle-react-native/src/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import createBeagleCoreUIService, { DefaultSchema, ErrorComponentParams } from '@zup-it/beagle-web'
 import { BeagleUIService, BeagleComponent, BeagleConfigReactNative } from 'common/types'
@@ -34,7 +34,7 @@ function createBeagleUIService<Schema = DefaultSchema>(config: BeagleConfigReact
     localAssetsPath: config.localAssetsPath || {},
     lifecycles: {
       ...config.lifecycles,
-      beforeRender: (uiTree) => {
+      beforeRender: uiTree => {
         translateStyles(uiTree)
         if (config.lifecycles?.beforeRender) config.lifecycles.beforeRender(uiTree)
       },

--- a/packages/beagle-react-native/src/lifecycles/translateStyles.ts
+++ b/packages/beagle-react-native/src/lifecycles/translateStyles.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleUIElement } from '@zup-it/beagle-web'
 import { removeInvalidCssProperties } from 'components/utils'

--- a/packages/beagle-react/package.json
+++ b/packages/beagle-react/package.json
@@ -22,10 +22,10 @@
     "test": "jest"
   },
   "dependencies": {
+    "@zup-it/beagle-web": "1.3.0",
     "lodash": "^4.17.15",
     "react-dom": "^16.13.1",
     "showdown": "^1.9.1",
-    "@zup-it/beagle-web": "1.3.0",
     "styled-components": "^5.1.1"
   },
   "peerDependencies": {
@@ -36,11 +36,12 @@
     "@types/lodash": "^4.14.149",
     "@types/react-dom": "^16.9.8",
     "@types/showdown": "^1.9.3",
+    "@types/styled-components": "^5.1.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.4",
     "enzyme-to-json": "^3.5.0",
     "jest-mock-extended": "^1.0.10",
-    "@types/styled-components": "^5.1.0"
+    "prettier": "^2.1.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/beagle-react/src/components/BeagleButton/styled.ts
+++ b/packages/beagle-react/src/components/BeagleButton/styled.ts
@@ -1,24 +1,24 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../commons.styled'
 
 export const StyledButton = styled.button`
-	border: 1px solid ${BeagleTheme.swampLight};
+  border: 1px solid ${BeagleTheme.swampLight};
   line-height: 34px;
   color: inherit;
   background: transparent;

--- a/packages/beagle-react/src/components/BeagleContainer/styled.ts
+++ b/packages/beagle-react/src/components/BeagleContainer/styled.ts
@@ -1,22 +1,22 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 
 export const StyledContainer = styled.div`
-	display: flex;
+  display: flex;
   flex-direction: column;
 `

--- a/packages/beagle-react/src/components/BeagleFutureListView/scroll.ts
+++ b/packages/beagle-react/src/components/BeagleFutureListView/scroll.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { useEffect, useRef } from 'react'
 import { ScrollInterface, NodeType } from './types'
@@ -37,9 +37,11 @@ function useScroll(props: ScrollInterface, deps: any[]) {
 
     const hasXScroll = overflowX !== 'visible' && overflowX !== 'hidden'
 
-    return (nodeElement.clientWidth === 0 ||
+    return (
+      nodeElement.clientWidth === 0 ||
       nodeElement.scrollWidth <= nodeElement.clientWidth ||
-      !hasXScroll)
+      !hasXScroll
+    )
   }
 
   const hasVerticalScroll = (nodeElement: NodeType): boolean => {
@@ -47,17 +49,21 @@ function useScroll(props: ScrollInterface, deps: any[]) {
 
     const overflowY = getComputedStyle(nodeElement).overflowY
     const hasYScroll = overflowY !== 'visible' && overflowY !== 'hidden'
-    return (nodeElement.clientHeight === 0 ||
+    return (
+      nodeElement.clientHeight === 0 ||
       nodeElement.scrollHeight <= nodeElement.clientHeight ||
-      !hasYScroll)
+      !hasYScroll
+    )
   }
 
   const getParentNode = (nodeElement: NodeType): NodeType => {
     if (!nodeElement) return null
     if (nodeElement.nodeName === 'HTML') return nodeElement
 
-    if (direction === 'VERTICAL' && hasVerticalScroll(nodeElement) ||
-      direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
+    if (
+      (direction === 'VERTICAL' && hasVerticalScroll(nodeElement)) ||
+      (direction === 'HORIZONTAL' && hasHorizontalScroll(nodeElement))
+    )
       return getParentNode(nodeElement.parentNode as HTMLElement)
 
     return nodeElement
@@ -72,7 +78,7 @@ function useScroll(props: ScrollInterface, deps: any[]) {
       return parentNode as NodeType
     }
 
-    return (elementRef.current as NodeType)
+    return elementRef.current as NodeType
   }
 
   const callOnScrollEnd = () => {
@@ -86,23 +92,20 @@ function useScroll(props: ScrollInterface, deps: any[]) {
     let screenPercentage: number
     if (direction === 'VERTICAL') {
       const scrollPosition = node.scrollTop
-      screenPercentage = (scrollPosition /
-        (node.scrollHeight - node.clientHeight)) * 100
+      screenPercentage = (scrollPosition / (node.scrollHeight - node.clientHeight)) * 100
     } else {
       const scrollPosition = node.scrollLeft
-      screenPercentage = (scrollPosition /
-        (node.scrollWidth - node.clientWidth)) * 100
+      screenPercentage = (scrollPosition / (node.scrollWidth - node.clientWidth)) * 100
     }
 
     const isOverThreshold = scrollEndThreshold && Math.ceil(screenPercentage) >= scrollEndThreshold
     if (isOverThreshold) callOnScrollEnd()
   }
 
-  const canScrollContent = (element: HTMLElement) => (
+  const canScrollContent = (element: HTMLElement) =>
     direction === 'HORIZONTAL'
       ? element.scrollWidth > element.clientWidth
       : element.scrollHeight > element.clientHeight
-  )
 
   useEffect(() => {
     if (!hasRendered) return
@@ -112,7 +115,7 @@ function useScroll(props: ScrollInterface, deps: any[]) {
       if (node !== undefined && node !== null) node.removeEventListener('scroll', calcPercentage)
       node = referenceNode
 
-      const parent = (node && node.nodeName !== 'HTML') ? node : window
+      const parent = node && node.nodeName !== 'HTML' ? node : window
 
       if (!canScrollContent(parent instanceof Window ? document.body : parent)) callOnScrollEnd()
 

--- a/packages/beagle-react/src/components/BeagleFutureListView/styled.ts
+++ b/packages/beagle-react/src/components/BeagleFutureListView/styled.ts
@@ -1,31 +1,31 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { Direction } from 'common/models'
 
 interface StyledListViewInterface {
-  direction: Direction,
-  useParentScroll?: boolean,
+  direction: Direction
+  useParentScroll?: boolean
 }
 
 export const StyledListView = styled.div<StyledListViewInterface>`
   display: flex;
-  flex-direction: ${({ direction }) => direction === 'VERTICAL' ? 'column' : 'row'};
-  overflow: ${({ useParentScroll }) => useParentScroll ? 'inherit' : 'auto'};
-  width: ${({ direction }) => direction === 'HORIZONTAL' ? '100%' : 'auto'};
-  height: ${({ direction }) => direction === 'VERTICAL' ? '100%' : 'auto'};
+  flex-direction: ${({ direction }) => (direction === 'VERTICAL' ? 'column' : 'row')};
+  overflow: ${({ useParentScroll }) => (useParentScroll ? 'inherit' : 'auto')};
+  width: ${({ direction }) => (direction === 'HORIZONTAL' ? '100%' : 'auto')};
+  height: ${({ direction }) => (direction === 'VERTICAL' ? '100%' : 'auto')};
 `

--- a/packages/beagle-react/src/components/BeagleFutureListView/types.ts
+++ b/packages/beagle-react/src/components/BeagleFutureListView/types.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleUIElement } from '@zup-it/beagle-web'
 import { BeagleDefaultComponent, Direction } from 'common/models'
@@ -21,25 +21,25 @@ import { BeagleComponent } from 'common/types'
 export type NodeType = HTMLElement | null
 
 export interface BeagleListViewInterface extends BeagleDefaultComponent, BeagleComponent {
-  direction: Direction,
-  dataSource: any[],
-  iteratorName?: string,
-  onInit?: () => void,
-  onScrollEnd?: () => void,
-  scrollEndThreshold?: number,
-  template: BeagleUIElement,
-  useParentScroll?: boolean,
+  direction: Direction
+  dataSource: any[]
+  iteratorName?: string
+  onInit?: () => void
+  onScrollEnd?: () => void
+  scrollEndThreshold?: number
+  template: BeagleUIElement
+  useParentScroll?: boolean
   /* the property "key" is not allowed in React. Since this is not a rule for Beagle, every time
   Beagle receives "key", it transforms it into "_key" */
-  _key?: string,
-  __suffix__?: string,
+  _key?: string
+  __suffix__?: string
 }
 
 export interface ScrollInterface {
-  direction: Direction,
-  onScrollEnd?: () => void,
-  scrollEndThreshold: number,
-  useParentScroll: boolean,
-  elementRef: React.MutableRefObject<HTMLDivElement>,
-  hasRendered: boolean,
+  direction: Direction
+  onScrollEnd?: () => void
+  scrollEndThreshold: number
+  useParentScroll: boolean
+  elementRef: React.MutableRefObject<HTMLDivElement>
+  hasRendered: boolean
 }

--- a/packages/beagle-react/src/components/BeagleImage/styled.ts
+++ b/packages/beagle-react/src/components/BeagleImage/styled.ts
@@ -1,27 +1,27 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 
 export interface StyledImageInterface {
-  mode?: string,
+  mode?: string
 }
 
 export const StyledImage = styled.img<StyledImageInterface>`
-  object-fit: ${({ mode }) => mode };
+  object-fit: ${({ mode }) => mode};
   width: inherit;
   height: inherit;
   min-width: inherit;

--- a/packages/beagle-react/src/components/BeagleListView/styled.ts
+++ b/packages/beagle-react/src/components/BeagleListView/styled.ts
@@ -1,27 +1,27 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { Direction } from 'common/models'
 
 interface StyledListViewInterface {
-  direction: Direction,
+  direction: Direction
 }
 
 export const StyledListView = styled.div<StyledListViewInterface>`
   display: flex;
-  flex-direction: ${({ direction }) => direction === 'VERTICAL' ? 'column' : 'row'}
+  flex-direction: ${({ direction }) => (direction === 'VERTICAL' ? 'column' : 'row')};
 `

--- a/packages/beagle-react/src/components/BeagleLoading/styled.ts
+++ b/packages/beagle-react/src/components/BeagleLoading/styled.ts
@@ -1,24 +1,24 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../commons.styled'
 
 export const StyledLoading = styled.div`
-	width: 100vw;
+  width: 100vw;
   height: 100vh;
   position: fixed;
   top: 0;

--- a/packages/beagle-react/src/components/BeaglePageIndicator/styled.ts
+++ b/packages/beagle-react/src/components/BeaglePageIndicator/styled.ts
@@ -1,26 +1,26 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../commons.styled'
 
 interface StyledItemInterface {
-  selectedColor?: string,
-  unselectedColor?: string,
-  selected: boolean,
+  selectedColor?: string
+  unselectedColor?: string
+  selected: boolean
 }
 
 export const StyledBeaglePageView = styled.div`
@@ -64,19 +64,21 @@ export const StyledOrderList = styled.ol`
 `
 
 export const StyledItemList = styled.li<StyledItemInterface>`
-  width: .625rem;
-  height: .625rem;
+  width: 0.625rem;
+  height: 0.625rem;
   cursor: no-drop;
   border-radius: 50%;
   margin: 10px;
-  background-color: ${({ selected, selectedColor, unselectedColor }) => selected ?
-    selectedColor || BeagleTheme.swamp : unselectedColor || BeagleTheme.swampTransparent}
+  background-color: ${({ selected, selectedColor, unselectedColor }) =>
+    selected
+      ? selectedColor || BeagleTheme.swamp
+      : unselectedColor || BeagleTheme.swampTransparent};
 `
 
 export const StyleContentItems = styled.div`
   margin: 0 30px;
-  > :not(.active) { 
-    display: none; 
+  > :not(.active) {
+    display: none;
   }
   > .active {
     display: block;

--- a/packages/beagle-react/src/components/BeaglePageView/styled.ts
+++ b/packages/beagle-react/src/components/BeaglePageView/styled.ts
@@ -1,26 +1,26 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { PageIndicatorInterface } from 'common/models'
 import { BeagleTheme } from '../commons.styled'
 
 interface StyledItemInterface {
-  pageIndicator?: PageIndicatorInterface,
-  selected: boolean,
+  pageIndicator?: PageIndicatorInterface
+  selected: boolean
 }
 
 export const StyledBeaglePageView = styled.div`
@@ -64,20 +64,21 @@ export const StyledOrderList = styled.ol`
 `
 
 export const StyledItemList = styled.li<StyledItemInterface>`
-  width: .625rem;
-  height: .625rem;
+  width: 0.625rem;
+  height: 0.625rem;
   cursor: pointer;
   border-radius: 50%;
   margin: 10px;
-  background-color: ${({ selected, pageIndicator }) => selected ?
-    (pageIndicator && pageIndicator.selectedColor) || BeagleTheme.swamp :
-    (pageIndicator && pageIndicator.unselectedColor) || BeagleTheme.swampTransparent}
+  background-color: ${({ selected, pageIndicator }) =>
+    selected
+      ? (pageIndicator && pageIndicator.selectedColor) || BeagleTheme.swamp
+      : (pageIndicator && pageIndicator.unselectedColor) || BeagleTheme.swampTransparent};
 `
 
 export const StyleContentItems = styled.div`
   margin: 0 30px;
-  > :not(.active) { 
-    display: none; 
+  > :not(.active) {
+    display: none;
   }
   > .active {
     display: block;

--- a/packages/beagle-react/src/components/BeagleTabBar/styled.ts
+++ b/packages/beagle-react/src/components/BeagleTabBar/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../commons.styled'
@@ -42,7 +42,7 @@ export const StyledBeagleTabItemContent = styled.div`
   }
 `
 
-export const StyledBeagleImage= styled(BeagleImage) `
+export const StyledBeagleImage = styled(BeagleImage)`
   max-width: 80px;
   max-height: 80px;
 `

--- a/packages/beagle-react/src/components/BeagleTabView/BeagleTabItem/styled.ts
+++ b/packages/beagle-react/src/components/BeagleTabView/BeagleTabItem/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../../commons.styled'
@@ -35,7 +35,7 @@ export const StyledBeagleTabItemHeader = styled.div`
   }
 `
 
-export const StyledBeagleImage= styled(BeagleImage) `
+export const StyledBeagleImage = styled(BeagleImage)`
   max-width: 80px;
   max-height: 80px;
 `

--- a/packages/beagle-react/src/components/BeagleTabView/context.ts
+++ b/packages/beagle-react/src/components/BeagleTabView/context.ts
@@ -1,24 +1,24 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { createContext } from 'react'
 
 export interface TabViewContextInterface {
-  activeTab: string,
-  setActiveTab: (id: string) => void,
+  activeTab: string
+  setActiveTab: (id: string) => void
 }
 
 const context = createContext<TabViewContextInterface>({} as TabViewContextInterface)

--- a/packages/beagle-react/src/components/BeagleTabView/lifecycles.ts
+++ b/packages/beagle-react/src/components/BeagleTabView/lifecycles.ts
@@ -1,24 +1,24 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { IdentifiableBeagleUIElement } from '@zup-it/beagle-web'
 
 export function transformItems(tabView: IdentifiableBeagleUIElement) {
   if (!Array.isArray(tabView.children)) return
-  tabView.children.forEach((child) => {
+  tabView.children.forEach(child => {
     child._beagleComponent_ = 'beagle:tabitem'
   })
 }

--- a/packages/beagle-react/src/components/BeagleTabView/styled.ts
+++ b/packages/beagle-react/src/components/BeagleTabView/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 

--- a/packages/beagle-react/src/components/BeagleText/styled.ts
+++ b/packages/beagle-react/src/components/BeagleText/styled.ts
@@ -1,29 +1,29 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { TextAlignment } from 'common/models'
 
 interface StyledTextInterface {
-	textColor?: string,
-	alignment?: TextAlignment,
+  textColor?: string
+  alignment?: TextAlignment
 }
 
 export const StyledText = styled.p<StyledTextInterface>`
-	color: ${({ textColor }) =>  textColor ? textColor : 'inherit'};
-	text-align: ${({ alignment }) => alignment ? alignment : 'inherit'};
+  color: ${({ textColor }) => (textColor ? textColor : 'inherit')};
+  text-align: ${({ alignment }) => (alignment ? alignment : 'inherit')};
   margin: 0;
 `

--- a/packages/beagle-react/src/components/BeagleTouchable/styled.ts
+++ b/packages/beagle-react/src/components/BeagleTouchable/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 

--- a/packages/beagle-react/src/components/BeagleWebView/styled.ts
+++ b/packages/beagle-react/src/components/BeagleWebView/styled.ts
@@ -1,24 +1,23 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 
-
 export const StyledWebView = styled.iframe`
-    width: inherit;
-    border: none;
-    align-self:normal;
+  width: inherit;
+  border: none;
+  align-self: normal;
 `

--- a/packages/beagle-react/src/components/Markdown/styled.ts
+++ b/packages/beagle-react/src/components/Markdown/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 
@@ -60,13 +60,13 @@ export const Container = styled.div`
   */
 
   code {
-    background-color: rgba(27,31,35,.05);
+    background-color: rgba(27, 31, 35, 0.05);
     border-radius: 3px;
     font-size: 85%;
     margin: 0;
     word-wrap: break-word;
-    padding: .2em .4em;
-    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+    padding: 0.2em 0.4em;
+    font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
   }
 
   pre > code {
@@ -171,7 +171,9 @@ export const Container = styled.div`
     color: #0366d6;
   }
 
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     border-bottom: 1px solid #eaecef;
     color: #111;
   }

--- a/packages/beagle-react/src/components/Modal/styled.ts
+++ b/packages/beagle-react/src/components/Modal/styled.ts
@@ -13,7 +13,7 @@ export const StyledModal = styled.div`
   justify-content: center;
 
   > div {
-    background-color: #FFF;
+    background-color: #fff;
     border-radius: 25px;
     padding: 30px;
   }

--- a/packages/beagle-react/src/components/Spinner/index.ts
+++ b/packages/beagle-react/src/components/Spinner/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 import { BeagleTheme } from '../commons.styled'

--- a/packages/beagle-react/src/components/TextArea/styled.ts
+++ b/packages/beagle-react/src/components/TextArea/styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import styled from 'styled-components'
 
@@ -30,4 +30,3 @@ export const Label = styled.p`
 export const StyledTextArea = styled.textarea`
   flex: 1;
 `
-

--- a/packages/beagle-react/src/components/commons.styled.ts
+++ b/packages/beagle-react/src/components/commons.styled.ts
@@ -1,23 +1,23 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 export const BeagleTheme = {
   swamp: '#001B26',
-  swampLight:  'rgba(0, 27, 38, 0.8)',
-  swampTransparent:  'rgba(0, 27, 38, 0.1)',
+  swampLight: 'rgba(0, 27, 38, 0.8)',
+  swampTransparent: 'rgba(0, 27, 38, 0.1)',
   athensGray: '#F5F7F9',
   blackTransparent: 'rgba(0, 0, 0, 0.1)',
   darkGray: 'rgba(0, 0, 0, 0.75);',

--- a/packages/beagle-react/src/components/index.ts
+++ b/packages/beagle-react/src/components/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import BeagleButton from './BeagleButton'
 import BeagleText from './BeagleText'

--- a/packages/beagle-react/src/components/types.ts
+++ b/packages/beagle-react/src/components/types.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { ChangeEvent, FocusEvent } from 'react'
 

--- a/packages/beagle-react/src/components/utils/animation.ts
+++ b/packages/beagle-react/src/components/utils/animation.ts
@@ -1,20 +1,20 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import { keyframes }  from 'styled-components'
+import { keyframes } from 'styled-components'
 
 export const spin = keyframes`
   from {

--- a/packages/beagle-react/src/index.ts
+++ b/packages/beagle-react/src/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import createBeagleCoreUIService, { DefaultSchema, ErrorComponentParams } from '@zup-it/beagle-web'
 import { BeagleConfig, BeagleUIService, BeagleComponent } from 'common/types'

--- a/packages/common/__tests__/utils/array.spec.ts
+++ b/packages/common/__tests__/utils/array.spec.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { filterBooleanArray } from '../../utils/array'
 

--- a/packages/common/models/beagle-button.model.ts
+++ b/packages/common/models/beagle-button.model.ts
@@ -2,10 +2,9 @@ import { ClickEvent } from '@zup-it/beagle-web'
 import { BeagleComponent } from '../types'
 import { BeagleDefaultComponent } from './types'
 
-
 export interface BeagleButtonInterface extends BeagleDefaultComponent, BeagleComponent {
-  text: string,
-  onPress?: () => void,
-  clickAnalyticsEvent?: ClickEvent,
-  disabled?: boolean, 
+  text: string
+  onPress?: () => void
+  clickAnalyticsEvent?: ClickEvent
+  disabled?: boolean
 }

--- a/packages/common/models/beagle-container.model.ts
+++ b/packages/common/models/beagle-container.model.ts
@@ -1,23 +1,23 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { ScreenEvent } from '@zup-it/beagle-web'
 import { BeagleDefaultComponent } from './types'
 
 export interface BeagleContainerInterface extends BeagleDefaultComponent {
-  onInit?: () => void,
-  screenAnalyticsEvent?: ScreenEvent,
+  onInit?: () => void
+  screenAnalyticsEvent?: ScreenEvent
 }

--- a/packages/common/models/beagle-futurelistview.model.ts
+++ b/packages/common/models/beagle-futurelistview.model.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleUIElement } from '@zup-it/beagle-web'
 import { BeagleComponent } from '../types'
@@ -21,25 +21,25 @@ import { Direction, BeagleDefaultComponent } from './types'
 export type NodeType = HTMLElement | null
 
 export interface BeagleFutureListViewInterface extends BeagleDefaultComponent, BeagleComponent {
-  direction: Direction,
-  dataSource: any[],
-  iteratorName?: string,
-  onInit?: () => void,
-  onScrollEnd?: () => void,
-  scrollEndThreshold?: number,
-  template: BeagleUIElement,
-  useParentScroll?: boolean,
+  direction: Direction
+  dataSource: any[]
+  iteratorName?: string
+  onInit?: () => void
+  onScrollEnd?: () => void
+  scrollEndThreshold?: number
+  template: BeagleUIElement
+  useParentScroll?: boolean
   /* the property "key" is not allowed in React. Since this is not a rule for Beagle, every time
   Beagle receives "key", it transforms it into "_key" */
-  _key?: string,
-  __suffix__?: string,
+  _key?: string
+  __suffix__?: string
 }
 
 export interface ScrollInterface {
-  direction: Direction,
-  onScrollEnd?: () => void,
-  scrollEndThreshold: number,
-  useParentScroll: boolean,
-  elementRef: React.MutableRefObject<HTMLDivElement>,
-  hasRendered: boolean,
+  direction: Direction
+  onScrollEnd?: () => void
+  scrollEndThreshold: number
+  useParentScroll: boolean
+  elementRef: React.MutableRefObject<HTMLDivElement>
+  hasRendered: boolean
 }

--- a/packages/common/models/beagle-image.model.ts
+++ b/packages/common/models/beagle-image.model.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BeagleDefaultComponent } from './types'
 
 export type ImageMode = 'FIT_XY' | 'FIT_CENTER' | 'CENTER_CROP' | 'CENTER'
@@ -20,18 +20,18 @@ export type ImageMode = 'FIT_XY' | 'FIT_CENTER' | 'CENTER_CROP' | 'CENTER'
 export type ImagePathMode = 'local' | 'remote'
 
 export interface ImagePath {
-  _beagleImagePath_: ImagePathMode,
-  url: string,
-  mobileId?: string,
+  _beagleImagePath_: ImagePathMode
+  url: string
+  mobileId?: string
 }
 
 export interface Accessibility {
-  accessible: boolean,
-  accessibilityLabel?: string,
+  accessible: boolean
+  accessibilityLabel?: string
 }
 
 export interface BeagleImageInterface extends BeagleDefaultComponent {
-  path: ImagePath,
-  mode?: ImageMode,
-  accessibility?: Accessibility,
+  path: ImagePath
+  mode?: ImageMode
+  accessibility?: Accessibility
 }

--- a/packages/common/models/beagle-input.model.ts
+++ b/packages/common/models/beagle-input.model.ts
@@ -5,18 +5,17 @@ export type InputHandler = (event: { value: string }) => void
 export type InputType = 'DATE' | 'EMAIL' | 'PASSWORD' | 'NUMBER' | 'TEXT'
 
 export interface BeagleTextInputInterface extends BeagleDefaultComponent {
-  value: string,
-  onChange?: InputHandler,
-  onFocus?: InputHandler,
-  onBlur?: InputHandler,
-  disabled: boolean,
-  readOnly?: boolean,
-  placeholder?: string,
-  type?: InputType,
+  value: string
+  onChange?: InputHandler
+  onFocus?: InputHandler
+  onBlur?: InputHandler
+  disabled: boolean
+  readOnly?: boolean
+  placeholder?: string
+  type?: InputType
 }
 
 export interface BeagleTextAreaInterface extends BeagleTextInputInterface {
-  name?: string,
-  label?: string,
+  name?: string
+  label?: string
 }
-

--- a/packages/common/models/beagle-lazy.model.ts
+++ b/packages/common/models/beagle-lazy.model.ts
@@ -1,21 +1,21 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleComponent } from '../types'
 
 export interface BeagleLazyInterface extends BeagleComponent {
-  path: string,
+  path: string
 }

--- a/packages/common/models/beagle-listview.model.ts
+++ b/packages/common/models/beagle-listview.model.ts
@@ -1,5 +1,5 @@
 import { BeagleDefaultComponent, Direction } from './types'
 
 export interface BeagleListViewInterface extends BeagleDefaultComponent {
-  direction: Direction,
+  direction: Direction
 }

--- a/packages/common/models/beagle-modal.model.ts
+++ b/packages/common/models/beagle-modal.model.ts
@@ -1,6 +1,6 @@
 import { BeagleDefaultComponent } from './types'
 
 export interface BeagleModalInterface extends BeagleDefaultComponent {
-  isOpen: boolean,
-  onClose: () => void,
+  isOpen: boolean
+  onClose: () => void
 }

--- a/packages/common/models/beagle-pageindicator.model.ts
+++ b/packages/common/models/beagle-pageindicator.model.ts
@@ -1,22 +1,22 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 export interface PageIndicatorInterface {
-  selectedColor?: string,
-  unselectedColor?: string,
-  numberOfPages?: number,
-  currentPage?: number,
+  selectedColor?: string
+  unselectedColor?: string
+  numberOfPages?: number
+  currentPage?: number
 }

--- a/packages/common/models/beagle-pageview.model.ts
+++ b/packages/common/models/beagle-pageview.model.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BeagleDefaultComponent } from './types'
 import { PageIndicatorInterface } from './beagle-pageindicator.model'
 
@@ -20,9 +20,9 @@ export interface BeaglePageViewInterface extends BeagleDefaultComponent {
   /**
    * @deprecated Since version 1.1. Will be deleted in version 2.0.
    * Use pageIndicator as a component instead.
-  */
-  pageIndicator?: PageIndicatorInterface,
-  onPageChange?: (index: number) => void,
-  currentPage?: number,
-  showArrow?: boolean,
+   */
+  pageIndicator?: PageIndicatorInterface
+  onPageChange?: (index: number) => void
+  currentPage?: number
+  showArrow?: boolean
 }

--- a/packages/common/models/beagle-simpleform.model.ts
+++ b/packages/common/models/beagle-simpleform.model.ts
@@ -1,21 +1,21 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleDefaultComponent } from './types'
 
 export interface FormInterface extends BeagleDefaultComponent {
-  onSubmit: () => void,
+  onSubmit: () => void
 }

--- a/packages/common/models/beagle-tabbar.model.ts
+++ b/packages/common/models/beagle-tabbar.model.ts
@@ -1,30 +1,30 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleDefaultComponent } from './types'
 import { ImagePath } from './beagle-image.model'
 
 export interface ItemTitle {
-  title?: string,
-  icon?: ImagePath,
+  title?: string
+  icon?: ImagePath
 }
 
 export interface BeagleTabBarInterface extends BeagleDefaultComponent {
-  onTabSelection?: (item: number) => void,
-  currentTab?: number,
-  items: ItemTitle[],
-  styleId?: string,
+  onTabSelection?: (item: number) => void
+  currentTab?: number
+  items: ItemTitle[]
+  styleId?: string
 }

--- a/packages/common/models/beagle-text.model.ts
+++ b/packages/common/models/beagle-text.model.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BeagleDefaultComponent } from './types'
 
 export type TextAlignment = 'LEFT' | 'CENTER' | 'RIGHT' | 'INHERIT'
@@ -20,8 +20,7 @@ export type TextAlignment = 'LEFT' | 'CENTER' | 'RIGHT' | 'INHERIT'
 export type MobileAlignment = 'auto' | 'center' | 'left' | 'right'
 
 export interface BeagleTextInterface extends BeagleDefaultComponent {
-  text: string,
-  textColor?: string,
-  alignment?: TextAlignment,
+  text: string
+  textColor?: string
+  alignment?: TextAlignment
 }
-

--- a/packages/common/models/beagle-touchable.model.ts
+++ b/packages/common/models/beagle-touchable.model.ts
@@ -1,23 +1,23 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { ClickEvent } from '@zup-it/beagle-web'
 import { BeagleDefaultComponent } from './types'
 
 export interface BeagleTouchableInterface extends BeagleDefaultComponent {
-  onPress: () => void,
-  clickAnalyticsEvent?: ClickEvent,
+  onPress: () => void
+  clickAnalyticsEvent?: ClickEvent
 }

--- a/packages/common/models/beagle-webview.model.ts
+++ b/packages/common/models/beagle-webview.model.ts
@@ -1,21 +1,21 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { BeagleDefaultComponent } from './types'
 
 export interface BeagleWebViewInterface<T> extends BeagleDefaultComponent<T> {
-  url: string,
+  url: string
 }

--- a/packages/common/models/index.ts
+++ b/packages/common/models/index.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export * from './beagle-image.model'
 export * from './beagle-text.model'
 export * from './beagle-button.model'

--- a/packages/common/models/types.ts
+++ b/packages/common/models/types.ts
@@ -1,24 +1,24 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { StyleProp } from 'react-native'
 
-export type Direction =  'VERTICAL' | 'HORIZONTAL'
+export type Direction = 'VERTICAL' | 'HORIZONTAL'
 
 export interface BeagleDefaultComponent<T = React.CSSProperties | StyleProp<any>> {
-  style?: T,
-  className?: string,
+  style?: T
+  className?: string
 }

--- a/packages/common/provider.ts
+++ b/packages/common/provider.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { createContext } from 'react'
 import { BeagleUIReactNativeService, BeagleUIService } from './types'

--- a/packages/common/renderer.ts
+++ b/packages/common/renderer.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { Fragment, FC, createElement, ComponentClass } from 'react'
 import { map } from 'lodash'
@@ -35,7 +35,7 @@ const createReactComponentTree = <Schema>(
   }
 
   const { _beagleComponent_, children, id, context, ...props } = ui
-  
+
   if (!_beagleComponent_) return createElement(Fragment)
 
   const Component = getComponentByCaseInsensitiveKey(components, _beagleComponent_)
@@ -49,7 +49,8 @@ const createReactComponentTree = <Schema>(
 
   const viewContentManager = contentManagerMap.get(viewId, id)
   const componentChildren = map(children, child =>
-    createReactComponentTree(components, child, viewId, contentManagerMap, BeagleId))
+    createReactComponentTree(components, child, viewId, contentManagerMap, BeagleId)
+  )
   const componentProps = { ...props, key: id, viewContentManager }
 
   return createElement(BeagleId, { id, key: id }, [

--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { FC, MutableRefObject } from 'react'
 import {
@@ -31,29 +31,29 @@ import {
 
 export interface BeagleConfig<Schema = DefaultSchema> extends BeagleCoreConfig<Schema> {
   components: {
-    'custom:error'?: FC<{}> | FC<ErrorComponentParams>,
-    'custom:loading'?: FC<{}>,
+    'custom:error'?: FC<{}> | FC<ErrorComponentParams>
+    'custom:loading'?: FC<{}>
   } & {
     [K in keyof Schema]: FC<Schema[K]>
-  },
+  }
 }
 
-export interface BeagleConfigReactNative<Schema = DefaultSchema> extends BeagleConfig<Schema>{
-  localAssetsPath?: Record<string, number>,
+export interface BeagleConfigReactNative<Schema = DefaultSchema> extends BeagleConfig<Schema> {
+  localAssetsPath?: Record<string, number>
 }
 
 export interface BeagleUIService<Schema = DefaultSchema> extends BeagleCoreService {
-  getConfig: () => BeagleConfig<Schema>,
+  getConfig: () => BeagleConfig<Schema>
 }
 
 export interface BeagleUIReactNativeService<Schema = DefaultSchema> extends BeagleCoreService {
-  getConfig: () => BeagleConfigReactNative<Schema>,
+  getConfig: () => BeagleConfigReactNative<Schema>
 }
 
 export type ViewContentManager = CoreViewContentManager
 
 export interface BeagleComponent {
-  viewContentManager?: ViewContentManager,
+  viewContentManager?: ViewContentManager
 }
 
 export { DataContext }
@@ -65,39 +65,39 @@ export interface LegacyLoadParams {
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  path?: string,
+  path?: string
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  fallback?: BeagleUIElement,
+  fallback?: BeagleUIElement
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  method?: HttpMethod,
+  method?: HttpMethod
   /**
    * @deprecated
    */
-  headers?: Record<string, string>,
+  headers?: Record<string, string>
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  shouldShowLoading?: boolean,
+  shouldShowLoading?: boolean
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  shouldShowError?: boolean,
+  shouldShowError?: boolean
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  strategy?: Strategy,
+  strategy?: Strategy
   /**
    * @deprecated
    */
-  loadingComponent?: string,
+  loadingComponent?: string
   /**
    * @deprecated since v1.3. Will be removed in 2.0.
    */
-  errorComponent?: string,
+  errorComponent?: string
 }
 
 // todo: remove the "extends" for v2.0.
@@ -105,29 +105,29 @@ export interface BeagleRemoteViewType extends LegacyLoadParams {
   /**
    * the id of this beagle view. Will be assigned a random id if none is provided.
    */
-  id?: string,
+  id?: string
   /**
    * React ref to attach a reference to the BeagleView to. Useful for manipulating the BeagleView
    * manually.
    */
-  viewRef?: MutableRefObject<BeagleView | undefined>,
+  viewRef?: MutableRefObject<BeagleView | undefined>
   /**
    * The initial route to navigate the BeagleView to. If this property changes, the navigation
    * history is reseted and the view is navigated to the new route. If you need to specify headers
    * or the http method, you should take a look into navigation controllers or custom http clients,
    * both can be set in the configuration for the Beagle Service.
    */
-  route?: string,
+  route?: string
   /**
    * The options to perform http requests (http method, headers and cache strategy) for all
    * navigations in this BeagleView. If not specified, will use the default options.
    */
-  networkOptions?: NetworkOptions,
+  networkOptions?: NetworkOptions
   /**
    * Tells which navigation controller to use until a new one is declared. The navigation controller
    * is responsible for the visual feedback of a navigation: the loading and error components, for
    * instance. This property is useful to setup the first request, which is not controlled by the
    * backend.
    */
-  controllerId?: string,
+  controllerId?: string
 }

--- a/packages/common/useComponent.ts
+++ b/packages/common/useComponent.ts
@@ -1,26 +1,21 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { useState, useEffect, useContext, useMemo } from 'react'
-import {
-  BeagleUIElement,
-  BeagleView,
-  logger,
-  LoadParams,
-} from '@zup-it/beagle-web'
+import { BeagleUIElement, BeagleView, logger, LoadParams } from '@zup-it/beagle-web'
 import { uniqueId } from 'lodash'
 import BeagleProvider from './provider'
 import { BeagleRemoteViewType } from './types'
@@ -36,13 +31,12 @@ function useComponent({
   const beagleService = useContext(BeagleProvider)
   const [uiTree, setUiTree] = useState<BeagleUIElement>()
   const [viewID, setViewID] = useState(id)
-  
-  if (!beagleService)
-    throw Error('Couldn\'t find a BeagleProvider in the component tree!')
+
+  if (!beagleService) throw Error("Couldn't find a BeagleProvider in the component tree!")
 
   const beagleView = useMemo<BeagleView>(() => {
     if (!id) setViewID(uniqueId())
-    
+
     const view = beagleService.createView(networkOptions, controllerId)
     view.subscribe(setUiTree)
     if (viewRef) viewRef.current = view
@@ -63,9 +57,15 @@ function useComponent({
     const deprecatedKeys = Object.keys(deprecated)
 
     if (deprecatedKeys.length) {
-      logger.warn(`The following properties in the BeagleRemoteView are deprecated and will be removed in v2.0: ${deprecatedKeys.join(', ')}.\nYou should use "route" to specify the path to the first view and "navigationOptions" for further request setup.`)
+      logger.warn(
+        `The following properties in the BeagleRemoteView are deprecated and will be removed in v2.0: ${deprecatedKeys.join(
+          ', '
+        )}.\nYou should use "route" to specify the path to the first view and "navigationOptions" for further request setup.`
+      )
       if (route) {
-        logger.warn('You shouldn\'t mix the new BeagleRemoteView properties with the deprecated ones. All deprecated properties will be ignored.')
+        logger.warn(
+          "You shouldn't mix the new BeagleRemoteView properties with the deprecated ones. All deprecated properties will be ignored."
+        )
       } else if (deprecated.path) {
         beagleView.fetch(deprecated as LoadParams)
       }

--- a/packages/common/utils/array.ts
+++ b/packages/common/utils/array.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { NonNull } from '../types'
 

--- a/packages/common/utils/beagleComponent.ts
+++ b/packages/common/utils/beagleComponent.ts
@@ -1,21 +1,21 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BeagleConfig, ComponentName } from '@zup-it/beagle-web'
 
-function createMapOfKeys<Schema> (components: BeagleConfig<Schema>['components']) {
+function createMapOfKeys<Schema>(components: BeagleConfig<Schema>['components']) {
   const keys = Object.keys(components)
   return keys.reduce((result, key) => ({ ...result, [key.toLowerCase()]: key }), {})
 }
@@ -24,15 +24,15 @@ const getLowercaseMapOfKeys = (<Schema>() => {
   type ComponentMap = BeagleConfig<Schema>['components']
   type ComponentKeyMap = Record<string, ComponentName<Schema>>
   const memo: Map<ComponentMap, ComponentKeyMap> = new Map()
-  
+
   return (components: BeagleConfig<Schema>['components']) => {
     if (!memo.has(components)) memo.set(components, createMapOfKeys(components))
     return memo.get(components)
   }
 })()
 
-export const getComponentByCaseInsensitiveKey = <Schema> (
-  components: BeagleConfig<Schema>['components'], 
+export const getComponentByCaseInsensitiveKey = <Schema>(
+  components: BeagleConfig<Schema>['components'],
   name: ComponentName<Schema>
 ) => {
   const lowercaseKeyMap = getLowercaseMapOfKeys(components) || {}

--- a/packages/common/utils/commons.styled.ts
+++ b/packages/common/utils/commons.styled.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 export const BeagleTheme = {
   swamp: '#001B26',

--- a/packages/common/utils/listview.ts
+++ b/packages/common/utils/listview.ts
@@ -1,18 +1,18 @@
 /*
-  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *  http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-*/
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { Tree, BeagleUIElement, logger, ViewContentManager } from '@zup-it/beagle-web'
 
@@ -22,11 +22,14 @@ export function renderListViewDynamicItems(
   template: BeagleUIElement,
   _key: string | undefined,
   __suffix__: string | undefined,
-  iteratorName: string) {
+  iteratorName: string
+) {
   if (!Array.isArray(dataSource)) return
 
   if (!viewContentManager) {
-    return logger.error('The beagle:listView component should only be used inside a view rendered by Beagle.')
+    return logger.error(
+      'The beagle:listView component should only be used inside a view rendered by Beagle.'
+    )
   }
 
   const element = viewContentManager.getElement() as BeagleUIElement


### PR DESCRIPTION
**- What I did**
Implemented prettier configuration to help to make the code follow the same formatting. I changed the eslint file because prettier doesn't cover this eslint rule, and it is not necessary to typescript files.

I did it because is a lot faster and easier to format code this way, and it will make sure all code maintainers are following the same code formatting. Also because I found some code formatting inconsistencies. 

**- How I did it**
I followed my actual prettier configuration, then I made some alteration to not change too much the code formatting.

To make sure I didn't change the code logic, I passed every file to check the file changes.

**- How to verify it**
Compare the file changes, to check if you all agree with my prettier configuration suggestion.

**- Description for the changelog**
Prettier configuration to the project follow the same rules.
