### PR TITLE
Fixing external PR validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,7 +67,6 @@ jobs:
       run: cd react && yarn lint
     
     - name: test
-      if: ${{ failure() }}
       run: cd react/packages/beagle-react && yarn test
 
     - name: test and comment

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,18 +65,19 @@ jobs:
     
     - name: lint
       run: cd react && yarn lint
+    
+    - name: test
+      if: ${{ failure() }}
+      run: cd react/packages/beagle-react && yarn test
 
-    - name: Jest Annotations & Coverage
+    - name: test and comment
+      continue-on-error: true
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         working-directory: "react/packages/beagle-react"
         test-command: "yarn test --maxWorkers=2"
-        
-    - name: tests only
-      if: ${{ failure() }}
-      run: cd react/packages/beagle-react && yarn test
 
     - name: type-check
       run: cd react && yarn build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,7 @@ jobs:
       run: cd react && yarn lint
 
     - name: Jest Annotations & Coverage
+      if: ${{ secrets.GITHUB_TOKEN != null }}
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,7 +76,7 @@ jobs:
         test-command: "yarn test --maxWorkers=2"
         
     - name: tests only
-      if: failure()
+      if: ${{ failure() }}
       run: yarn test
 
     - name: type-check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        coverage-comment: ${{ secrets.GITHUB_TOKEN != null }} 
         working-directory: "react"
         test-command: "yarn test --maxWorkers=2"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,13 +67,17 @@ jobs:
       run: cd react && yarn lint
 
     - name: Jest Annotations & Coverage
+      continue-on-error: true
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        coverage-comment: false
         working-directory: "react"
         test-command: "yarn test --maxWorkers=2"
+        
+    - name: tests only
+      if: failure()
+      run: yarn test
 
     - name: type-check
       run: cd react && yarn build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,12 +71,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        working-directory: "react"
+        working-directory: "react/packages/beagle-react"
         test-command: "yarn test --maxWorkers=2"
         
     - name: tests only
       if: ${{ failure() }}
-      run: yarn test
+      run: cd react/packages/beagle-react && yarn test
 
     - name: type-check
       run: cd react && yarn build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,11 +67,11 @@ jobs:
       run: cd react && yarn lint
 
     - name: Jest Annotations & Coverage
-      if: ${{ secrets.GITHUB_TOKEN != null }}
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        coverage-comment: false
         working-directory: "react"
         test-command: "yarn test --maxWorkers=2"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,7 +67,6 @@ jobs:
       run: cd react && yarn lint
 
     - name: Jest Annotations & Coverage
-      continue-on-error: true
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I tried everything I could. Unfortunately I could not make `mattallty/jest-github-action` run only if `secrets.GITHUB_TOKEN` exists. I also could not find a way to prevent `mattallty/jest-github-action` from posting comments only if `secrets.GITHUB_TOKEN` exists.

Since I don't see the point in re-implementing `mattallty/jest-github-action` just to prevent it from running for external PRs, I decided to run the tests twice:

- 1st time: tests are run using `yarn test`, if they fail, the job fails and PR can't be merged
- 2nd time: tests are re-run with `mattallty/jest-github-action` so it can make the comments it needs to. But, if it fails, the job won't fail and PR can still be merged.

It's not ideal, but it's the fastest solution for now. The ideal implementation would be to make this comment ourselves, without the need for `mattallty/jest-github-action`. Another solution would be to make a PR to `mattallty/jest-github-action` that implements our needs.

I also fixed a problem where not all tests for beagle-react were running for `mattallty/jest-github-action`. For some reason, running `yarn test` at the root is not working as expected. I altered it to run the tests at `packages/beagle-react`.