### PR TITLE
Fix/text overflow wrap

### DIFF
--- a/packages/beagle-react/src/__tests__/components/__snapshots__/BeagleError.spec.tsx.snap
+++ b/packages/beagle-react/src/__tests__/components/__snapshots__/BeagleError.spec.tsx.snap
@@ -5,12 +5,12 @@ exports[`Beagle snapshot Error 1`] = `
   class="Test Class"
 >
   <p
-    class="sc-bdfBwQ hhkMbO"
+    class="sc-bdfBwQ eliSds"
   >
     Sorry!
   </p>
   <p
-    class="sc-bdfBwQ btnxKk"
+    class="sc-bdfBwQ fTPwPK"
   >
     An unexpected error happened while loading your page.
   </p>

--- a/packages/beagle-react/src/components/BeagleText/styled.ts
+++ b/packages/beagle-react/src/components/BeagleText/styled.ts
@@ -27,4 +27,5 @@ export const StyledText = styled.p<StyledTextInterface>`
 	text-align: ${({ alignment }) => alignment ? alignment : 'inherit'};
   margin: 0;
   white-space: pre-wrap;
+  overflow-wrap: break-word;
 `


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Fixed problem where text without spaces would overflow the parent container instead of breaking.

**- How I did it**
Added the css property `overflow-wrap: word-break;`

**- How to verify it**
Playground and Landing Page. See the screenshots below:

![landingPage](https://i.ibb.co/nmmRfLf/Captura-de-Tela-2020-11-26-a-s-12-13-37.png)
![playground-react](https://i.ibb.co/dWx79z0/Captura-de-Tela-2020-11-26-a-s-12-16-36.png)
![playground-angular](https://i.ibb.co/gWHBfWH/Captura-de-Tela-2020-11-26-a-s-12-41-54.png)

**- Description for the changelog**
- Fixes problem where text would not break when overflowing its parent.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
