### PR TITLE
Deprecated custom modal and text-area

### DIFF
--- a/packages/beagle-react/src/components/Modal/index.tsx
+++ b/packages/beagle-react/src/components/Modal/index.tsx
@@ -20,6 +20,10 @@ import { buildAccessibility } from '../../../../common/utils/accessibility'
 import withTheme from '../utils/withTheme'
 import { StyledModal } from './styled'
 
+/**
+ * @deprecate since version 1.8.0.
+ * This component will be removed in a future version.
+*/
 const Modal: FC<BeagleModalInterface> = props => {
   const { isOpen, onClose, style, className, children, accessibility } = props
   const elementRef = useRef<HTMLDivElement>(null)

--- a/packages/beagle-react/src/components/Modal/index.tsx
+++ b/packages/beagle-react/src/components/Modal/index.tsx
@@ -15,6 +15,7 @@
 */
 
 import React, { FC, useEffect, useRef } from 'react'
+import { logger } from '@zup-it/beagle-web'
 import { BeagleModalInterface } from 'common/models'
 import { buildAccessibility } from '../../../../common/utils/accessibility'
 import withTheme from '../utils/withTheme'
@@ -43,6 +44,7 @@ const Modal: FC<BeagleModalInterface> = props => {
 
   useEffect(() => {
     document.addEventListener('keyup', closeOnEsc)
+    logger.warn('This component is deprecated since version 1.8.0 and will be removed in a future version.')
     return () => document.removeEventListener('keyup', closeOnEsc)
   }, [])
 

--- a/packages/beagle-react/src/components/Modal/index.tsx
+++ b/packages/beagle-react/src/components/Modal/index.tsx
@@ -21,7 +21,7 @@ import withTheme from '../utils/withTheme'
 import { StyledModal } from './styled'
 
 /**
- * @deprecate since version 1.8.0.
+ * @deprecated since version 1.8.0.
  * This component will be removed in a future version.
 */
 const Modal: FC<BeagleModalInterface> = props => {

--- a/packages/beagle-react/src/components/TextArea/index.tsx
+++ b/packages/beagle-react/src/components/TextArea/index.tsx
@@ -22,7 +22,7 @@ import withTheme from '../utils/withTheme'
 import { InputGroup, Label, StyledTextArea } from './styled'
 
 /**
- * @deprecate since version 1.8.0.
+ * @deprecated since version 1.8.0.
  * This component will be removed in a future version.
 */
 const TextArea: FC<BeagleTextAreaInterface> = ({

--- a/packages/beagle-react/src/components/TextArea/index.tsx
+++ b/packages/beagle-react/src/components/TextArea/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { FC } from 'react'
+import { logger } from '@zup-it/beagle-web'
 import { BeagleTextAreaInterface } from 'common/models'
 import { InputEvent, InputHandler } from '../types'
 import { buildAccessibility } from '../../../../common/utils/accessibility'
@@ -39,6 +40,7 @@ const TextArea: FC<BeagleTextAreaInterface> = ({
   accessibility,
 }) => {
   const a11y = buildAccessibility(accessibility)
+  logger.warn('This component is deprecated since version 1.8.0 and will be removed in a future version.')
 
   const handleEvent = (handler?: InputHandler) => (event: InputEvent) => {
     if (!handler) return

--- a/packages/beagle-react/src/components/TextArea/index.tsx
+++ b/packages/beagle-react/src/components/TextArea/index.tsx
@@ -21,6 +21,10 @@ import { buildAccessibility } from '../../../../common/utils/accessibility'
 import withTheme from '../utils/withTheme'
 import { InputGroup, Label, StyledTextArea } from './styled'
 
+/**
+ * @deprecate since version 1.8.0.
+ * This component will be removed in a future version.
+*/
 const TextArea: FC<BeagleTextAreaInterface> = ({
   value,
   label,

--- a/packages/common/models/beagle-input.model.ts
+++ b/packages/common/models/beagle-input.model.ts
@@ -24,7 +24,7 @@ export interface BeagleTextInputInterface extends BeagleDefaultComponent {
 }
 
 /**
- * @deprecate since version 1.8.0.
+ * @deprecated since version 1.8.0.
  * This interface will be removed in a future version.
 */
 export interface BeagleTextAreaInterface extends BeagleTextInputInterface {

--- a/packages/common/models/beagle-input.model.ts
+++ b/packages/common/models/beagle-input.model.ts
@@ -4,6 +4,7 @@ export type InputHandler = (event: { value: string }) => void
 
 export type InputType = 'DATE' | 'EMAIL' | 'PASSWORD' | 'NUMBER' | 'TEXT'
 
+
 export interface BeagleTextInputInterface extends BeagleDefaultComponent {
   value: string,
   onChange?: InputHandler,
@@ -22,6 +23,10 @@ export interface BeagleTextInputInterface extends BeagleDefaultComponent {
   showError?: boolean,
 }
 
+/**
+ * @deprecate since version 1.8.0.
+ * This interface will be removed in a future version.
+*/
 export interface BeagleTextAreaInterface extends BeagleTextInputInterface {
   name?: string,
   label?: string,

--- a/packages/common/models/beagle-modal.model.ts
+++ b/packages/common/models/beagle-modal.model.ts
@@ -1,7 +1,7 @@
 import { BeagleDefaultComponent } from './types'
 
 /**
- * @deprecate since version 1.8.0.
+ * @deprecated since version 1.8.0.
  * This interface will be removed in a future version.
 */
 export interface BeagleModalInterface extends BeagleDefaultComponent {

--- a/packages/common/models/beagle-modal.model.ts
+++ b/packages/common/models/beagle-modal.model.ts
@@ -1,5 +1,9 @@
 import { BeagleDefaultComponent } from './types'
 
+/**
+ * @deprecate since version 1.8.0.
+ * This interface will be removed in a future version.
+*/
 export interface BeagleModalInterface extends BeagleDefaultComponent {
   isOpen: boolean,
   onClose: () => void,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Deprecated the custom components modal and text-area

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
