### PR TITLE
Fix: Avoid unnecessary logic when no Data Source is provided on Dynamic List

### DIFF
--- a/packages/beagle-react/package.json
+++ b/packages/beagle-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-react",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "beagle-react/src/index.js",
   "typings": "beagle-react/src/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/index.tsx
+++ b/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/index.tsx
@@ -73,7 +73,7 @@ const DynamicListCoreComponent: FC<DynamicViewInterface> = ({
   }, [])
 
   useEffect(() => {
-    if (!Array.isArray(dataSource)) return
+    if (!Array.isArray(dataSource) || dataSource.length === 0) return
     
     if (!viewContentManager) {
       return logger.error('The beagle:listView component should only be used inside a view rendered by Beagle.')
@@ -86,7 +86,7 @@ const DynamicListCoreComponent: FC<DynamicViewInterface> = ({
       (templatesRaw && Array.isArray(templatesRaw) && templatesRaw.length)
     if (!hasAnyTemplate) {
       return logger.error('The beagle:listView requires a template or multiple templates to be rendered!')
-    }      
+    }
 
     const componentTag = element._beagleComponent_.toLowerCase()
     const templateItems = [


### PR DESCRIPTION
**- What I did**
Avoid unnecessary logic when no Data Source is provided on Dynamic List.
Also increased the version of the package to stop the warnings on the playground.

**- How I did it**
Adding a simple condition to the dataSource if at the beginning of the function.

**- How to verify it**
Create a JSON with the dataSource empty and run it, the same rule applies for asynchronous DataSource, it should not throw any warning or message.
