### PR TITLE
Fix: DynamicLists - componentManager was wrongly giving ids and suffixes to components

### DIFF
--- a/packages/beagle-react/package.json
+++ b/packages/beagle-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-react",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "main": "beagle-react/src/index.js",
   "typings": "beagle-react/src/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/index.tsx
+++ b/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/index.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { FC, useEffect, useRef, Children, useMemo } from 'react'
-import { BeagleUIElement, DataContext, IdentifiableBeagleUIElement, TemplateManagerItem } from '@zup-it/beagle-web'
+import { BeagleUIElement, DataContext, IdentifiableBeagleUIElement, TemplateManagerItem, Tree } from '@zup-it/beagle-web'
 import { logger } from '@zup-it/beagle-web'
 import { TemplateManager } from '@zup-it/beagle-web'
 import withTheme from '../../utils/withTheme'
@@ -102,15 +102,18 @@ const DynamicListCoreComponent: FC<DynamicViewInterface> = ({
       templates: manageableTemplates,
     }
     const componentManager = (component: IdentifiableBeagleUIElement, index: number) => {
-      const iterationKey = _key && dataSource[index][_key] ? dataSource[index][_key] : index
-      const baseId = component.id ? `${component.id}${suffix}` : `${element.id}:${index}`
-      const hasSuffix = ['beagle:listview', 'beagle:gridview'].includes(componentTag)
-      return {
-        ...component,
-        id: `${baseId}:${iterationKey}`,
-        key: iterationKey,
-        ...(hasSuffix ? { __suffix__: `${suffix}:${iterationKey}` } : {}),
-      }
+      Tree.forEach(component, (treeComponent, componentIndex) => {
+        const iterationKey = _key && dataSource[index][_key] ? dataSource[index][_key] : index
+        const baseId = treeComponent.id 
+          ? `${treeComponent.id}${suffix}` 
+          : `${element.id}:${componentIndex}`
+        const hasSuffix = ['beagle:listview', 'beagle:gridview'].includes(componentTag)
+        treeComponent.id = `${baseId}:${iterationKey}`
+        if (hasSuffix) {
+          treeComponent.__suffix__ = `${suffix}:${iterationKey}`
+        }
+      })
+      return component
     }
     const contexts: DataContext[][] = dataSource.map(item => [{ id: iteratorName, value: item }])
     renderer.doTemplateRender(manager, element.id, contexts, componentManager)


### PR DESCRIPTION
**- What I did**
Fixed how the `componentManager` was handling ids and components for children.

**- How I did it**
Brought back the behavior using the `Tree` and looping on each children of the new component, attributing the right ids and suffixes.

**- How to verify it**
Create a `DynamicList` where it has as children elements with ids (especially with `listview` and `gridview`)

Closes [#275 on Angular (but was needed here too)](https://github.com/ZupIT/beagle-web-angular/issues/275)