### PR TITLE
Fix: Publish CLI NPM Auth Key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,19 @@ jobs:
         if: ${{ env.SHOULD_PUBLISH == 'true' }}
         run: cd packages/beagle-react && yarn build
 
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        if: ${{ env.SHOULD_PUBLISH == 'true' }}
+        uses: abhilash1in/aws-secrets-manager-action@v1.0.1
+        with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: us-east-1
+            secrets: |
+                beagle/web/publish
+            parse-json: true
+
       - name: publish to NPM
         if: ${{ env.SHOULD_PUBLISH == 'true' }}
         run: cd packages/beagle-react && cd dist && npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH }}
+          NODE_AUTH_TOKEN: ${{ env.BEAGLE_WEB_PUBLISH_NPM_AUTH }}


### PR DESCRIPTION
**- What I did**
Updated the Publish Action to use the new NPM Key through AWS.