### PR TITLE
Fixes typo in listview styled component

### DIFF
--- a/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/styled.ts
+++ b/packages/beagle-react/src/components/BeagleDynamicLists/DynamicListCore/styled.ts
@@ -39,7 +39,7 @@ export const StyledDynamicViewsInterface = styled.div<StyledDynamicViewsInterfac
   overflow: ${({ useParentScroll }) => useParentScroll ? 'inherit' : 'auto'};
   width: ${({ direction }) => direction === 'HORIZONTAL' ? '100%' : 'auto'};
   height: ${({ direction }) => direction === 'VERTICAL' ? '100%' : 'auto'};
-  & ::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     display: ${({ isScrollIndicatorVisible }) => isScrollIndicatorVisible ? 'auto' : 'none'};
   }
   -ms-overflow-style: ${({ isScrollIndicatorVisible }) => isScrollIndicatorVisible ?


### PR DESCRIPTION
Signed-off-by: Hector Custódio <hector.custodio@zup.com.br>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Removed white space typo in listview styled components which made the property not to be applied properly
-->
