### PR TITLE
fix: init and warnings supression

### DIFF
--- a/cli/init/boilerplate/app.tsx
+++ b/cli/init/boilerplate/app.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react'
 import './App.css'
 import { BeagleProvider, BeagleRemoteView } from '@zup-it/beagle-react'
 import BeagleService from './beagle/beagle-service'

--- a/cli/init/boilerplate/beagle-service.ts
+++ b/cli/init/boilerplate/beagle-service.ts
@@ -17,6 +17,6 @@
 import { createBeagleUIService } from '@zup-it/beagle-react'
 
 export default createBeagleUIService({
-  baseUrl: 'http://usebeagle.io.s3-website-sa-east-1.amazonaws.com/start/',
+  baseUrl: 'https://62ed756ec1ef25f3da7a5452.mockapi.io/start',
   components: {},
 })

--- a/cli/init/index.js
+++ b/cli/init/index.js
@@ -48,7 +48,7 @@
 
   await mkdir(`${srcPath}/${beaglePath}/`, { recursive: true })
   await createBeagleFile(beaglePath, 'beagle-service.ts')
-  await createBeagleFile('', 'app.tsx')
+  await createBeagleFile('', 'App.tsx')
   console.log("success! all configuration files were created correctly")
   process.exit()
 })()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "beagle-react/src/index.js",
   "typings": "beagle-react/src/index.d.ts",
   "license": "Apache-2.0",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -41,7 +41,7 @@ const createReactComponentTree = <Schema>(
 
   if (!Component) {
     console.error(
-      `Error: Beagle could not find component ${_beagleComponent_}. This component and its children won't be rendered.`
+      `Error: Beagle could not find component ${_beagleComponent_ as string}. This component and its children won't be rendered.`
     )
     return createElement(Fragment)
   }


### PR DESCRIPTION
Closes: #267 

**- What I did**
- Refactored the `cli/index.js` script
- Suppressed the warnings created by the newer version of `react-scripts`
- Fixed the link of the starting sample
- Updated the react version

PS: Due to some issues related to Create React App (CRA) after version 5, this file is needed to be created.
More here:
- Discussion: https://github.com/facebook/create-react-app/discussions/11767
- Pull to br merged: https://github.com/facebook/create-react-app/pull/11752

**- How to verify it**
Create a new react project following the tutorial.

**- Description for the changelog**
- Refactored the `cli/index.js` script
- Suppressed the warnings created by the newer version of `react-scripts`
- Fixed the link of the starting sample
- Updated the react version
